### PR TITLE
DM-44271: Use pre-configured template environment

### DIFF
--- a/python/lsst/ts/rubintv/templates/_layout.jinja
+++ b/python/lsst/ts/rubintv/templates/_layout.jinja
@@ -32,8 +32,8 @@ window.onpageshow = function (event) {
 <body class="{{ body_class }}">
     <script>
         window.APP_DATA = {}
-        window.APP_DATA.siteLocation = {{ site_location|tojson }}
-        window.APP_DATA.pathPrefix = {{ path_prefix|tojson }}
+        window.APP_DATA.siteLocation = {{ site_location|tojson if site_location else "null" }}
+        window.APP_DATA.pathPrefix = {{ path_prefix|tojson if path_prefix else "null" }}
     </script>
     <header>
         <div class="header-wrap">

--- a/python/lsst/ts/rubintv/templates_init.py
+++ b/python/lsst/ts/rubintv/templates_init.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from fastapi.templating import Jinja2Templates
+from jinja2 import Environment, FileSystemLoader
 from lsst.ts.rubintv import __version__
 from lsst.ts.rubintv.config import config
 from lsst.ts.rubintv.models.models_helpers import (
@@ -11,53 +12,27 @@ from lsst.ts.rubintv.models.models_helpers import get_image_viewer_link
 __all__ = ["get_templates"]
 
 
-# TODO: Use the commented-out code below as the basis for replacing
-# the method of mutating the templates.env object for setting up
-# the templating environment.
-# see DM-44271
-
-
 def get_templates() -> Jinja2Templates:
-    # point jinja2 to the templates dir.
-    templates = Jinja2Templates(
-        directory=Path(__file__).parent / "templates",
-        autoescape=False,
-        auto_reload=True,
-    )
+    loader = FileSystemLoader(Path(__file__).parent / "templates")
+
+    env = Environment(autoescape=True, auto_reload=True, loader=loader)
+
     # Prevent tojson() filter from re-ordering keys.
-    templates.env.policies["json.dumps_kwargs"] = {"sort_keys": False}
+    env.policies["json.dumps_kwargs"] = {"sort_keys": False}
 
     # Add filter to convert lists to dicts.
-    templates.env.filters["list_to_dict"] = list_to_dict
-    templates.env.globals["viewer_link"] = get_image_viewer_link
+    env.filters["list_to_dict"] = list_to_dict
+    env.globals["viewer_link"] = get_image_viewer_link
 
-    # Inject version as template global.
-    templates.env.globals.update(
-        version=__version__,
-        site_location=config.site_location,
-        path_prefix=config.path_prefix,
+    # Inject version etc. as template globals.
+    env.globals.update(
+        {
+            "version": __version__,
+            "site_location": config.site_location,
+            "path_prefix": config.path_prefix,
+        }
     )
 
+    templates = Jinja2Templates(env=env)
+
     return templates
-
-
-# def get_templates() -> Jinja2Templates:
-#     env = Environment(
-#         autoescape=True,
-#         auto_reload=True,
-#     )
-#     # Prevent tojson() filter from re-ordering keys.
-#     env.policies["json.dumps_kwargs"] = {"sort_keys": False}
-#     # Add filter to convert lists to dicts.
-#     env.filters["list_to_dict"] = list_to_dict
-#     env.globals["viewer_link"] = get_image_viewer_link
-#     # Inject version as template global.
-#     env.globals.update(version=__version__)
-
-#     # point jinja2 to the templates dir.
-#       templates = Jinja2Templates(
-#           directory=Path(__file__).parent / "templates",
-#           env=env
-#       )
-
-#     return templates


### PR DESCRIPTION
Responding to:
`/opt/homebrew/Caskroom/miniconda/base/envs/rubintv2/lib/python3.11/site-packages/starlette/templating.py:102: DeprecationWarning: Extra environment options are deprecated. Use a preconfigured jinja2.Environment instead.`