### PR TITLE
DM-44377: Fix reference to missing function

### DIFF
--- a/python/lsst/ts/rubintv/background/historicaldata.py
+++ b/python/lsst/ts/rubintv/background/historicaldata.py
@@ -210,7 +210,7 @@ class HistoricalPoller:
             text_report = text_reports[0]
             key = text_report.key
             client = self._clients[location.name]
-            text_obj = await client.get_metadata_obj(key)
+            text_obj = await client.async_get_object(key)
             report["text"] = text_obj
             nr_objs.remove(text_report)
         if nr_objs:


### PR DESCRIPTION
A function that was scrapped in a refactor was still being referenced in the creation of Night Report pages.