### PR TITLE
DM-44353: Bring up to date with Pydantic v2 validators

### DIFF
--- a/python/lsst/ts/rubintv/background/historicaldata.py
+++ b/python/lsst/ts/rubintv/background/historicaldata.py
@@ -274,7 +274,10 @@ class HistoricalPoller:
     async def get_metadata_for_date(
         self, location: Location, camera: Camera, day_obs: date
     ) -> dict[str, dict]:
-        loc_cam_date = f"{location.name}/{camera.metadata_from}/{day_obs}"
+        cam_name = camera.name
+        if camera.metadata_from:
+            cam_name = camera.metadata_from
+        loc_cam_date = f"{location.name}/{cam_name}/{day_obs}"
         return self._metadata.get(loc_cam_date, {})
 
     async def get_most_recent_day(

--- a/python/lsst/ts/rubintv/models/models.py
+++ b/python/lsst/ts/rubintv/models/models.py
@@ -7,21 +7,12 @@ from enum import Enum
 from typing import Any
 
 import structlog
-from pydantic import BaseModel, ConfigDict, validator
+from pydantic import BaseModel, ConfigDict
 from pydantic.dataclasses import dataclass
 from typing_extensions import NotRequired, TypedDict
 
 from .. import __version__
 from ..config import config
-
-__all__ = [
-    "Metadata",
-    "Location",
-    "Channel",
-    "Camera",
-    "Event",
-    "get_current_day_obs",
-]
 
 logger = structlog.get_logger("rubintv")
 
@@ -129,10 +120,6 @@ class Camera(HasButton):
     metadata_cols: dict[str, str] | None = None
     image_viewer_link: str = ""
     copy_row_template: str = ""
-
-    @validator("metadata_from", pre=True, always=True)
-    def default_metadata_from(cls: Any, v: Any, values: Any) -> Any:
-        return v or values.get("name", "")
 
     def seq_channels(self) -> list[Channel]:
         return [c for c in self.channels if not c.per_day]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ import pytest
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from lsst.ts.rubintv.main import create_app
 from lsst.ts.rubintv.models.models_init import ModelsInitiator
 from moto import mock_aws
@@ -49,7 +49,9 @@ async def mocked_client(
 ) -> AsyncIterator[Tuple[AsyncClient, RubinDataMocker]]:
     app, mocker = mocked_app
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
-    async with AsyncClient(app=app, base_url="http://127.0.0.1:8000/") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://127.0.0.1:8000/"
+    ) as client:
         yield client, mocker
 
 


### PR DESCRIPTION
Removes need to use `@validator` annotation.

Also deals with deprecated method of passing the app to `http_client`.

`/opt/homebrew/Caskroom/miniconda/base/envs/rubintv2/lib/python3.11/site-packages/httpx/_client.py:1426: DeprecationWarning: The 'app' shortcut is now deprecated. Use the explicit style 'transport=ASGITransport(app=...)' instead.`