### PR TITLE
DM-44681: Fix banner styling

### DIFF
--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -520,8 +520,8 @@ section
 
 .site-host-display
 	z-index: 24
-	margin-top: -30px
-	margin-bottom: auto
+	position: absolute
+	top: 0
 	padding: 9px
 	background-color: aquamarine
 	border-radius: 0 0 6px 6px


### PR DESCRIPTION
Fix the overlapping banner text in the header of ComCamSim.
From this:
<img width="580" alt="Screenshot 2024-06-04 at 22 27 10" src="https://github.com/lsst-ts/rubintv/assets/624222/97b2d472-6311-4dc8-9f8a-f97a669451e7">

to this:
<img width="497" alt="Screenshot 2024-06-04 at 22 37 07" src="https://github.com/lsst-ts/rubintv/assets/624222/5b73ab45-e019-4ff9-8afe-beab6628e8dd">

