### PR TITLE
DM-44303: Send new/reconnected client most recent data

### DIFF
--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -2,7 +2,6 @@ import asyncio
 
 import structlog
 from lsst.ts.rubintv.background.background_helpers import get_next_previous_from_table
-from lsst.ts.rubintv.handlers.handlers_helpers import ServiceMessageTypes as Service
 from lsst.ts.rubintv.handlers.websocket_notifiers import notify_ws_clients
 from lsst.ts.rubintv.models.models import (
     Camera,
@@ -10,8 +9,9 @@ from lsst.ts.rubintv.models.models import (
     Location,
     NightReport,
     NightReportPayload,
-    get_current_day_obs,
 )
+from lsst.ts.rubintv.models.models import ServiceMessageTypes as Service
+from lsst.ts.rubintv.models.models import get_current_day_obs
 from lsst.ts.rubintv.models.models_helpers import (
     make_table_from_event_list,
     objects_to_events,

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -271,6 +271,7 @@ class CurrentPoller:
         if to_update:
             night_report.plots = to_update
             self._nr_reports[loc_cam] = set(reports)
+        # Check for equality with empty NightReport (from pydantic.BaseModel)
         if night_report != NightReport():
             await notify_ws_clients(
                 "nightreport", Service.NIGHT_REPORT, loc_cam, night_report.model_dump()
@@ -403,8 +404,7 @@ class CurrentPoller:
                 ):
                     yield Service.CAMERA_PER_DAY, per_day
 
-                nr_exists = await self.night_report_exists(location.name, camera.name)
-                if nr_exists:
+                if await self.night_report_exists(location.name, camera.name):
                     yield Service.CAMERA_PER_DAY, {"nightReportLink": "current"}
 
             case "channel":
@@ -417,5 +417,7 @@ class CurrentPoller:
                 night_report = await self.get_current_night_report(
                     location.name, camera.name
                 )
+                # Check for equality with empty NightReport (from
+                # pydantic.BaseModel)
                 if night_report != NightReport():
                     yield Service.NIGHT_REPORT, night_report.model_dump()

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -245,7 +245,7 @@ class CurrentPoller:
         loc_cam: str,
         location: Location,
     ) -> None:
-        night_report: NightReport = NightReport
+        night_report: NightReport = NightReport()
         reports = await objects_to_ngt_report_data(report_objs)
         text_reports = [r for r in reports if r.group == "metadata"]
         if len(text_reports) > 1:
@@ -271,9 +271,9 @@ class CurrentPoller:
         if to_update:
             night_report.plots = to_update
             self._nr_reports[loc_cam] = set(reports)
-        if night_report:
+        if night_report != NightReport():
             await notify_ws_clients(
-                "nightreport", Service.NIGHT_REPORT, loc_cam, night_report
+                "nightreport", Service.NIGHT_REPORT, loc_cam, night_report.model_dump()
             )
         return
 
@@ -418,4 +418,4 @@ class CurrentPoller:
                     location.name, camera.name
                 )
                 if night_report != NightReport():
-                    yield Service.NIGHT_REPORT, night_report
+                    yield Service.NIGHT_REPORT, night_report.model_dump()

--- a/python/lsst/ts/rubintv/handlers/api.py
+++ b/python/lsst/ts/rubintv/handlers/api.py
@@ -11,7 +11,7 @@ from lsst.ts.rubintv.handlers.handlers_helpers import (
     get_camera_events_for_date,
     get_current_night_report_payload,
 )
-from lsst.ts.rubintv.models.models import Camera, Event, Location, NightReportPayload
+from lsst.ts.rubintv.models.models import Camera, Event, Location, NightReport
 from lsst.ts.rubintv.models.models_helpers import date_str_to_date, find_first
 
 api_router = APIRouter()
@@ -194,11 +194,11 @@ async def get_current_night_report_api(
 
 @api_router.get(
     "/{location_name}/{camera_name}/night_report/{date_str}",
-    response_model=NightReportPayload,
+    response_model=NightReport,
 )
 async def get_night_report_for_date(
     location_name: str, camera_name: str, date_str: str, request: Request
-) -> NightReportPayload:
+) -> NightReport:
     location, camera = await get_location_camera(location_name, camera_name, request)
     try:
         day_obs = date_str_to_date(date_str)

--- a/python/lsst/ts/rubintv/handlers/handlers_helpers.py
+++ b/python/lsst/ts/rubintv/handlers/handlers_helpers.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from datetime import date
-from enum import Enum
 from typing import Any, Callable
 
 import structlog
@@ -130,11 +129,3 @@ async def get_prev_next_event(
             raise HTTPException(423, "Historical data is being processed")
         nxt, prv = await hp.get_next_prev_event(location, camera, event)
     return {"next": nxt, "prev": prv}
-
-
-class ServiceMessageTypes(Enum):
-    CHANNEL_EVENT: str = "event"
-    CAMERA_TABLE: str = "channelData"
-    CAMERA_METADATA: str = "metadata"
-    CAMERA_PER_DAY: str = "perDay"
-    NIGHT_REPORT: str = "nightReport"

--- a/python/lsst/ts/rubintv/handlers/pages.py
+++ b/python/lsst/ts/rubintv/handlers/pages.py
@@ -333,7 +333,7 @@ async def get_historical_night_report_page(
     except ValueError:
         raise HTTPException(status_code=404, detail="Invalid date.")
 
-    night_report: NightReport | None
+    night_report: NightReport
     night_report, historical_busy = await try_historical_call(
         get_night_report_for_date,
         location_name,
@@ -341,9 +341,6 @@ async def get_historical_night_report_page(
         date_str,
         request,
     )
-
-    if night_report is not None:
-        night_report = night_report.model_dump()
 
     title = build_title(
         location.title,
@@ -359,7 +356,7 @@ async def get_historical_night_report_page(
             "location": location,
             "camera": camera.model_dump(),
             "date": day_obs,
-            "night_report": night_report,
+            "night_report": night_report.model_dump(),
             "historical_busy": historical_busy,
             "title": title,
         },

--- a/python/lsst/ts/rubintv/handlers/pages_helpers.py
+++ b/python/lsst/ts/rubintv/handlers/pages_helpers.py
@@ -2,7 +2,7 @@ from calendar import Calendar
 from datetime import date
 from typing import Any
 
-from lsst.ts.rubintv.models.models import NightReportPayload
+__all__ = ["month_names", "calendar_factory", "build_title", "to_dict"]
 
 
 def month_names() -> list[str]:
@@ -34,14 +34,3 @@ def to_dict(object: Any | None) -> dict | None:
     if object is None:
         return None
     return object.__dict__
-
-
-async def night_report_to_dict(
-    nr_payload: NightReportPayload,
-) -> dict[str, dict | list[dict]]:
-    if not nr_payload:
-        return {}
-    plots = []
-    for plot in nr_payload.get("plots", []):
-        plots.append(plot.__dict__)
-    return {"text": nr_payload.get("text", {}), "plots": plots}

--- a/python/lsst/ts/rubintv/handlers/websocket.py
+++ b/python/lsst/ts/rubintv/handlers/websocket.py
@@ -14,6 +14,7 @@ from lsst.ts.rubintv.handlers.websockets_clients import (
     websocket_to_client,
 )
 from lsst.ts.rubintv.models.models import Camera, Location
+from lsst.ts.rubintv.models.models import ServiceMessageTypes as Service
 from lsst.ts.rubintv.models.models_helpers import find_first
 
 data_ws_router = APIRouter()
@@ -76,7 +77,7 @@ async def data_websocket(
                     historical_busy = await websocket.app.state.historical.is_busy()
                     await websocket.send_json(
                         {
-                            "dataType": "historicalStatus",
+                            "dataType": Service.HISTORICAL_STATUS.value,
                             "payload": historical_busy,
                         }
                     )
@@ -146,7 +147,7 @@ async def attach_service(
         )
         return
 
-    location = await find_first(locations, "name", location_name)
+    location = find_first(locations, "name", location_name)
 
     if extra:
         channel_name = extra[0]

--- a/python/lsst/ts/rubintv/handlers/websocket_notifiers.py
+++ b/python/lsst/ts/rubintv/handlers/websocket_notifiers.py
@@ -43,12 +43,12 @@ async def notify_clients(
 
 
 async def send_notification(
-    websocket: WebSocket, data_type: Service, payload: Any
+    websocket: WebSocket, service: Service, payload: Any
 ) -> None:
     try:
         await websocket.send_json(
             {
-                "dataType": data_type.value,
+                "dataType": service.value,
                 "payload": payload,
                 "datestamp": get_current_day_obs().isoformat(),
             }
@@ -67,7 +67,8 @@ async def get_clients_to_notify(service_cam_id: str) -> list[UUID]:
 
 
 async def notify_all_status_change(historical_busy: bool) -> None:
-    key = "historicalStatus"
+    service = Service.HISTORICAL_STATUS
+    key = service.value
     tasks = []
     async with services_lock:
         if key not in services_clients:
@@ -82,7 +83,7 @@ async def notify_all_status_change(historical_busy: bool) -> None:
 
     # Prepare tasks for each websocket
     for websocket in websockets:
-        task = send_notification(websocket, "historicalStatus", historical_busy)
+        task = send_notification(websocket, service, historical_busy)
         tasks.append(task)
 
     # Use asyncio.gather to handle all tasks concurrently

--- a/python/lsst/ts/rubintv/handlers/websocket_notifiers.py
+++ b/python/lsst/ts/rubintv/handlers/websocket_notifiers.py
@@ -5,7 +5,6 @@ from uuid import UUID
 import structlog
 from fastapi import WebSocket
 from lsst.ts.rubintv.background.currentpoller import CurrentPoller
-from lsst.ts.rubintv.handlers.handlers_helpers import ServiceMessageTypes as Service
 from lsst.ts.rubintv.handlers.handlers_helpers import (
     get_camera_current_data,
     get_current_night_report_payload,
@@ -16,7 +15,9 @@ from lsst.ts.rubintv.handlers.websockets_clients import (
     services_clients,
     services_lock,
 )
-from lsst.ts.rubintv.models.models import Camera, Location, get_current_day_obs
+from lsst.ts.rubintv.models.models import Camera, Location
+from lsst.ts.rubintv.models.models import ServiceMessageTypes as Service
+from lsst.ts.rubintv.models.models import get_current_day_obs
 
 logger = structlog.get_logger("rubintv")
 

--- a/python/lsst/ts/rubintv/handlers/websocket_notifiers.py
+++ b/python/lsst/ts/rubintv/handlers/websocket_notifiers.py
@@ -4,13 +4,19 @@ from uuid import UUID
 
 import structlog
 from fastapi import WebSocket
+from lsst.ts.rubintv.background.currentpoller import CurrentPoller
+from lsst.ts.rubintv.handlers.handlers_helpers import ServiceMessageTypes as Service
+from lsst.ts.rubintv.handlers.handlers_helpers import (
+    get_camera_current_data,
+    get_current_night_report_payload,
+)
 from lsst.ts.rubintv.handlers.websockets_clients import (
     clients,
     clients_lock,
     services_clients,
     services_lock,
 )
-from lsst.ts.rubintv.models.models import get_current_day_obs
+from lsst.ts.rubintv.models.models import Camera, Location, get_current_day_obs
 
 logger = structlog.get_logger("rubintv")
 
@@ -41,11 +47,49 @@ async def notify_clients(
     logger.info("Finished sending updates")
 
 
-async def send_notification(websocket: WebSocket, data_type: str, payload: Any) -> None:
+async def notify_ws_of_latest(
+    websocket: WebSocket,
+    service_loc_cam: str,
+    location: Location,
+    camera: Camera,
+    channel_name: str,
+    service: str,
+) -> None:
+    match service:
+        case "camera":
+            data = await get_camera_current_data(
+                location, camera, websocket, use_historical=False
+            )
+            if data is None:
+                return
+            day_obs, channel_data, per_day, metadata, nr_exists, is_historical = data
+            await send_notification(websocket, Service.CAMERA_TABLE, channel_data)
+            await send_notification(websocket, Service.CAMERA_METADATA, metadata)
+            await send_notification(websocket, Service.CAMERA_PER_DAY, per_day)
+            if nr_exists:
+                await send_notification(
+                    websocket, Service.CAMERA_PER_DAY, "nightReportExists"
+                )
+        case "channel":
+            current_poller: CurrentPoller = websocket.app.state.current_poller
+            event = await current_poller.get_current_channel_event(
+                location.name, camera.name, channel_name
+            )
+            await send_notification(websocket, Service.CHANNEL_EVENT, event.__dict__)
+        case "nightreport":
+            day_obs, night_report = await get_current_night_report_payload(
+                location, camera, websocket
+            )
+            await send_notification(websocket, Service.NIGHT_REPORT, night_report)
+
+
+async def send_notification(
+    websocket: WebSocket, data_type: Service, payload: Any
+) -> None:
     try:
         await websocket.send_json(
             {
-                "dataType": data_type,
+                "dataType": data_type.value,
                 "payload": payload,
                 "datestamp": get_current_day_obs().isoformat(),
             }

--- a/python/lsst/ts/rubintv/models/models.py
+++ b/python/lsst/ts/rubintv/models/models.py
@@ -352,3 +352,11 @@ class Heartbeat:
             "isActive": bool(self.state.value),
             "nextExpected": self.next_expected.isoformat(),  # Convert datetime to string
         }
+
+
+class ServiceMessageTypes(Enum):
+    CHANNEL_EVENT: str = "event"
+    CAMERA_TABLE: str = "channelData"
+    CAMERA_METADATA: str = "metadata"
+    CAMERA_PER_DAY: str = "perDay"
+    NIGHT_REPORT: str = "nightReport"

--- a/python/lsst/ts/rubintv/models/models.py
+++ b/python/lsst/ts/rubintv/models/models.py
@@ -9,7 +9,6 @@ from typing import Any
 import structlog
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass
-from typing_extensions import NotRequired, TypedDict
 
 from .. import __version__
 from ..config import config
@@ -209,7 +208,7 @@ class Event:
 
 
 @dataclass
-class NightReport:
+class NightReportData:
     """Wrapper for a night report blob.
 
         -   Night Reports can be located in a given bucket using the prefix:
@@ -291,9 +290,9 @@ class NightReport:
         return int(f"0x{self.hash}", 0)
 
 
-class NightReportPayload(TypedDict):
-    text: NotRequired[dict]
-    plots: NotRequired[list[NightReport]]
+class NightReport(BaseModel):
+    text: dict[str, Any] | None = {}
+    plots: list[NightReportData] | None = []
 
 
 def get_current_day_obs() -> date:
@@ -360,3 +359,4 @@ class ServiceMessageTypes(Enum):
     CAMERA_METADATA: str = "metadata"
     CAMERA_PER_DAY: str = "perDay"
     NIGHT_REPORT: str = "nightReport"
+    HISTORICAL_STATUS: str = "historicalStatus"

--- a/python/lsst/ts/rubintv/models/models_helpers.py
+++ b/python/lsst/ts/rubintv/models/models_helpers.py
@@ -2,7 +2,16 @@ from datetime import date
 from typing import Any, Iterable
 
 import structlog
-from lsst.ts.rubintv.models.models import Camera, Channel, Event, NightReport
+from lsst.ts.rubintv.models.models import Camera, Channel, Event, NightReportData
+
+__all__ = [
+    "find_first",
+    "find_all",
+    "string_int_to_date",
+    "date_str_to_date",
+    "objects_to_events",
+    "objects_to_ngt_report_data",
+]
 
 
 def find_first(a_list: list[Any], key: str, to_match: str) -> Any | None:
@@ -88,12 +97,12 @@ async def objects_to_events(objects: list[dict]) -> list[Event]:
     return events
 
 
-async def objects_to_ngt_reports(objects: list[dict]) -> list[NightReport]:
+async def objects_to_ngt_report_data(objects: list[dict]) -> list[NightReportData]:
     logger = structlog.get_logger("rubintv")
-    night_reports: list[NightReport] = []
+    night_reports: list[NightReportData] = []
     for object in objects:
         try:
-            event = NightReport(**object)
+            event = NightReportData(**object)
             night_reports.append(event)
         except ValueError as e:
             logger.info(e)

--- a/src/js/components/NightReport.js
+++ b/src/js/components/NightReport.js
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { groupBy, sanitiseString } from '../modules/utils'
 
+// TODO: check that newly uploaded plots are updated in the display
+// see DM-44596 https://rubinobs.atlassian.net/browse/DM-44596
+
 function NightReportText ({ nightReport, selected }) {
   const data = nightReport.text || {}
   const efficiency = {}

--- a/src/js/components/PerDay.js
+++ b/src/js/components/PerDay.js
@@ -96,10 +96,10 @@ export default function PerDay ({ camera, initialDate, initialPerDay, initialNRL
         setNightReportLink("")
       }
 
-      if (dataType === 'perDay' && !data.nightReportExists) {
+      if (dataType === 'perDay' && !data.nightReportLink) {
         setPerDay(data)
       }
-      else if (dataType === 'perDay' && data.nightReportExists) {
+      else if (dataType === 'perDay' && data.nightReportLink) {
         setNightReportLink("current")
       }
     }

--- a/src/js/components/PerDay.js
+++ b/src/js/components/PerDay.js
@@ -96,10 +96,10 @@ export default function PerDay ({ camera, initialDate, initialPerDay, initialNRL
         setNightReportLink("")
       }
 
-      if (dataType === 'perDay' && data != "nightReportExists") {
+      if (dataType === 'perDay' && !data.nightReportExists) {
         setPerDay(data)
       }
-      else if (dataType === 'perDay' && data == "nightReportExists") {
+      else if (dataType === 'perDay' && data.nightReportExists) {
         setNightReportLink("current")
       }
     }

--- a/src/js/pages/night_report.js
+++ b/src/js/pages/night_report.js
@@ -18,7 +18,7 @@ import NightReport from '../components/NightReport'
   if (!window.APP_DATA.isHistorical) {
     // eslint-disable-next-line no-unused-vars
     const ws = new WebsocketClient()
-    ws.subscribe('service', 'camera', locationName, camera.name)
+    ws.subscribe('service', 'nightreport', locationName, camera.name)
   }
   const tableRoot = createRoot(_getById('night-report'))
   tableRoot.render(

--- a/tests/background/currentpoller_test.py
+++ b/tests/background/currentpoller_test.py
@@ -90,7 +90,7 @@ async def test_poll_buckets_for_today_process_and_store_seq_events(
         # The timeout error is expected
         pass
 
-    mocked_objs_keys = rubin_data_mocker.channel_objs.keys()
+    mocked_objs_keys = rubin_data_mocker.seq_objs.keys()
 
     # make sure the keys for the location/cameras match up
     current_keys = sorted([k for k in current_poller._events.keys()])
@@ -132,7 +132,7 @@ async def test_process_channel_objects(
 
     camera, location = await get_test_camera_and_location()
     loc_cam = f"{location.name}/{camera.name}"
-    objects = rubin_data_mocker.channel_objs[loc_cam]
+    objects = rubin_data_mocker.seq_objs[loc_cam]
 
     with (
         patch(

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -56,10 +56,6 @@ async def test_get_location(mocked_client: tuple[AsyncClient, RubinDataMocker]) 
     assert camera_names == page_slugs
 
 
-# below is valid test when run in isolation but not after either of the two
-# tests above. Commenting out to keep the test for future use.
-
-
 @pytest.mark.asyncio
 async def test_current_channels(
     mocked_client: tuple[AsyncClient, RubinDataMocker]

--- a/tests/mockdata.py
+++ b/tests/mockdata.py
@@ -93,6 +93,10 @@ class RubinDataMocker:
         -------
         None
         """
+
+        # TODO: keep adding to the add_data() functions
+        # see DM-44838 https://rubinobs.atlassian.net/browse/DM-44838
+
         for location in self._locations:
             loc_name = location.name
             self.events[loc_name] = []
@@ -134,9 +138,6 @@ class RubinDataMocker:
             A tuple containing a list of mock channel dictionaries and an
             updated empty channel string.
         """
-
-        # TODO: keep adding to the add_data() functions
-        # employ add_data() functions in websocket notifier tests
 
         channel_data: list[dict[str, str]] = []
         loc_cam = f"{location.name}/{camera.name}"


### PR DESCRIPTION
This was subject to requirements creep.

I realised that the strategy I had for passing messages to the web socket clients was based on arbirary strings & tried to limit that by employing an enum instead.

The night report classes have been re-typed/renamed for better checking.

Also, I was hoping to include a test in this commit to make sure that clients were indeed being sent the lastest data when appropriate and in doing that realised that the class for mocking data wasn't fit for doing that. The rest of that work is for DM-44838.