### PR TITLE
DM-44971: Remove reliance on timeouts in historical data collection testing

### DIFF
--- a/python/lsst/ts/rubintv/background/historicaldata.py
+++ b/python/lsst/ts/rubintv/background/historicaldata.py
@@ -35,7 +35,7 @@ class HistoricalPoller:
     # polling period in seconds
     CHECK_NEW_DAY_PERIOD = 5
 
-    def __init__(self, locations: list[Location]) -> None:
+    def __init__(self, locations: list[Location], test_mode: bool = False) -> None:
         self._clients: dict[str, S3Client] = {}
         self._metadata: dict[str, dict[str, str]] = {}
         self._events: dict[str, list[Event]] = {}
@@ -51,6 +51,8 @@ class HistoricalPoller:
         self._last_reload = get_current_day_obs()
 
         self.cam_year_rgx = re.compile(r"(\w+)\/([\d]{4})-[\d]{2}-[\d]{2}")
+
+        self.test_mode = test_mode
 
     async def clear_all_data(self) -> None:
         self._have_downloaded = False
@@ -81,6 +83,8 @@ class HistoricalPoller:
                     logger.info("Completed historical")
                     await notify_all_status_change(historical_busy=False)
                 else:
+                    if self.test_mode:
+                        break
                     await asyncio.sleep(self.CHECK_NEW_DAY_PERIOD)
         except Exception as e:
             logger.error(e)

--- a/tests/background/currentpoller_test.py
+++ b/tests/background/currentpoller_test.py
@@ -26,12 +26,6 @@ def current_poller(rubin_data_mocker: RubinDataMocker) -> CurrentPoller:
     return CurrentPoller(m.locations, test_mode=True)
 
 
-@pytest.fixture(scope="function")
-def c_poller_no_mock_data(rubin_data_mocker: RubinDataMocker) -> Any:
-    with mock_s3_service():
-        yield CurrentPoller(m.locations, test_mode=True)
-
-
 @pytest.mark.asyncio
 async def test_poll_buckets_for_todays_data(
     current_poller: CurrentPoller, rubin_data_mocker: RubinDataMocker
@@ -112,9 +106,8 @@ async def test_clear_all_data(current_poller: CurrentPoller) -> None:
 
 @pytest.mark.asyncio
 async def test_process_channel_objects(
-    c_poller_no_mock_data: CurrentPoller, rubin_data_mocker: RubinDataMocker
+    current_poller: CurrentPoller, rubin_data_mocker: RubinDataMocker
 ) -> None:
-    current_poller = c_poller_no_mock_data
     await current_poller.clear_all_data()
 
     camera, location = await get_test_camera_and_location()
@@ -148,9 +141,8 @@ async def test_process_channel_objects(
 
 @pytest.mark.asyncio
 async def test_update_channel_events(
-    c_poller_no_mock_data: CurrentPoller, rubin_data_mocker: RubinDataMocker
+    current_poller: CurrentPoller, rubin_data_mocker: RubinDataMocker
 ) -> None:
-    current_poller = c_poller_no_mock_data
     with (
         patch(
             "lsst.ts.rubintv.background.currentpoller." "notify_ws_clients",
@@ -170,9 +162,8 @@ async def test_update_channel_events(
 
 @pytest.mark.asyncio
 async def test_make_per_day_data(
-    c_poller_no_mock_data: CurrentPoller, rubin_data_mocker: RubinDataMocker
+    current_poller: CurrentPoller, rubin_data_mocker: RubinDataMocker
 ) -> None:
-    current_poller = c_poller_no_mock_data
     mocked_events = rubin_data_mocker.events
     for location in m.locations:
         for camera in location.cameras:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, AsyncIterator, Tuple
+from typing import Any, AsyncIterator, Iterator, Tuple
 
 import boto3
 import pytest
@@ -26,39 +26,27 @@ def aws_credentials() -> None:
     moto_credentials_file_path = (
         Path(__file__).parent.absolute() / "dummy_aws_credentials"
     )
-    print(f"Credentials file path: {moto_credentials_file_path}")
     os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(moto_credentials_file_path)
 
 
-@pytest_asyncio.fixture(scope="function")
-async def mocked_app(
-    aws_credentials: Any,
-) -> AsyncIterator[Tuple[FastAPI, RubinDataMocker]]:
+@pytest.fixture(scope="function")
+def mock_s3_client(aws_credentials: Any) -> Iterator[Any]:
     with mock_s3_service():
-        models = ModelsInitiator()
-        mocker = RubinDataMocker(models.locations, s3_required=True)
-        app = create_app()
-        async with LifespanManager(app):
-            yield app, mocker
-        mocker.cleanup()
+        yield boto3.client("s3", region_name="us-east-1")
 
 
 @pytest_asyncio.fixture(scope="function")
 async def mocked_client(
-    mocked_app: Tuple[FastAPI, RubinDataMocker]
-) -> AsyncIterator[Tuple[AsyncClient, RubinDataMocker]]:
-    app, mocker = mocked_app
-    """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://127.0.0.1:8000/"
-    ) as client:
-        yield client, mocker
-
-
-@pytest.fixture(scope="function")
-def mock_s3_client(aws_credentials: Any) -> Any:
-    with mock_s3_service():
-        yield boto3.client("s3", region_name="us-east-1")
+    mock_s3_client: Any,
+) -> AsyncIterator[Tuple[AsyncClient, FastAPI, RubinDataMocker]]:
+    app = create_app()
+    models = ModelsInitiator()
+    mocker = RubinDataMocker(models.locations, s3_required=True)
+    async with LifespanManager(app):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://127.0.0.1:8000/"
+        ) as client:
+            yield client, app, mocker
 
 
 @contextmanager

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -63,7 +63,6 @@ async def test_get_location(
 
 
 @pytest.mark.asyncio
-# @patch("lsst.ts.rubintv.main.HistoricalPoller")
 async def test_current_channels(
     mocked_client: tuple[AsyncClient, FastAPI, RubinDataMocker]
 ) -> None:

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -7,7 +7,9 @@ from itertools import chain
 
 import pytest
 from bs4 import BeautifulSoup
+from fastapi import FastAPI
 from httpx import AsyncClient
+from lsst.ts.rubintv.background.currentpoller import CurrentPoller
 from lsst.ts.rubintv.models.models import Location
 from lsst.ts.rubintv.models.models_helpers import find_first
 from lsst.ts.rubintv.models.models_init import ModelsInitiator
@@ -18,9 +20,11 @@ m = ModelsInitiator()
 
 
 @pytest.mark.asyncio
-async def test_get_home(mocked_client: tuple[AsyncClient, RubinDataMocker]) -> None:
+async def test_get_home(
+    mocked_client: tuple[AsyncClient, FastAPI, RubinDataMocker]
+) -> None:
     """Test that home page has links to every location"""
-    client, mocker = mocked_client
+    client, app, mocker = mocked_client
     response = await client.get("/rubintv/")
     html = await response.aread()
     parsed = BeautifulSoup(html, "html.parser")
@@ -36,9 +40,11 @@ async def test_get_home(mocked_client: tuple[AsyncClient, RubinDataMocker]) -> N
 
 
 @pytest.mark.asyncio
-async def test_get_location(mocked_client: tuple[AsyncClient, RubinDataMocker]) -> None:
+async def test_get_location(
+    mocked_client: tuple[AsyncClient, FastAPI, RubinDataMocker]
+) -> None:
     """Test that location page has links to cameras"""
-    client, mocker = mocked_client
+    client, app, mocker = mocked_client
     location_name = "summit-usdf"
     location = find_first(m.locations, "name", location_name)
     assert type(location) is Location
@@ -57,15 +63,17 @@ async def test_get_location(mocked_client: tuple[AsyncClient, RubinDataMocker]) 
 
 
 @pytest.mark.asyncio
+# @patch("lsst.ts.rubintv.main.HistoricalPoller")
 async def test_current_channels(
-    mocked_client: tuple[AsyncClient, RubinDataMocker]
+    mocked_client: tuple[AsyncClient, FastAPI, RubinDataMocker]
 ) -> None:
-    """Test that location page has links to cameras"""
-    client, mocker = mocked_client
-    print("in test_current_channels")
-    print(mocker.empty_channel)
-    # allow historicaldata time to sort info
-    await asyncio.sleep(1)
+    client, app, mocker = mocked_client
+
+    cp: CurrentPoller = app.state.current_poller
+    cp.test_mode = True
+    while cp.completed_first_poll is not True:
+        await asyncio.sleep(0.1)
+
     for location in m.locations:
         for camera in location.cameras:
             loc_cam = f"{location.name}/{camera.name}"
@@ -75,12 +83,9 @@ async def test_current_channels(
                     f"/current/{seq_chan.name}"
                 )
                 response = await client.get(url)
-
                 assert response.status_code == 200
-
                 html = await response.aread()
                 parsed = BeautifulSoup(html, "html.parser")
-
                 if mocker.empty_channel[loc_cam] == seq_chan.name:
                     assert parsed.select(".event-error")
                     assert not parsed.select(".event-info")

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
 from lsst.ts.rubintv.config import config
 
@@ -10,8 +11,10 @@ from ..mockdata import RubinDataMocker
 
 
 @pytest.mark.asyncio
-async def test_get_index(mocked_client: tuple[AsyncClient, RubinDataMocker]) -> None:
-    client, mocker = mocked_client
+async def test_get_index(
+    mocked_client: tuple[AsyncClient, FastAPI, RubinDataMocker]
+) -> None:
+    client, app, mocker = mocked_client
     """Test ``GET /``"""
     response = await client.get("/")
     assert response.status_code == 200

--- a/tests/mockdata.py
+++ b/tests/mockdata.py
@@ -54,27 +54,6 @@ class RubinDataMocker:
         self.metadata: dict[str, dict[str, str]] = {}
         self.mock_up_data()
 
-    def cleanup(self) -> None:
-        print("Started cleaning...")
-        self.delete_buckets()
-        self.last_seq = {}
-        self._locations = []
-        self.s3_required = False
-        self.location_channels = {}
-        self.seq_objs = {}
-        self.events = {}
-        self.metadata = {}
-        print("Finished cleaning...")
-
-    def delete_buckets(self) -> None:
-        if self.s3_required:
-            s3 = boto3.resource("s3", region_name="us-east-1")
-            for location in self._locations:
-                bucket_name = location.bucket_name
-                bucket = s3.Bucket(bucket_name)
-                print(f"Emptying bucket: {bucket_name}")
-                bucket.objects.all().delete()
-
     def create_buckets(self) -> None:
         for location in self._locations:
             bucket_name = location.bucket_name


### PR DESCRIPTION
Also generally cleans up test fixtures.