### PR TITLE
DM-45118: Rewrite blocks and bottlenecks

### DIFF
--- a/locust/locustfile.py
+++ b/locust/locustfile.py
@@ -1,0 +1,67 @@
+import json
+import random
+import time
+
+from locust_plugins.users.socketio import SocketIOUser
+
+from locust import HttpUser, between, task  # type: ignore
+
+
+class RubinTVHttpUser(HttpUser):
+    wait_time = between(5, 10)
+
+    @task
+    def get_most_recent_summit_auxtel_channels(self) -> None:
+        for chan in ["monitor", "imexam", "specexam", "mount"]:
+            self.client.get(f"summit-usdf/auxtel/current/{chan}")
+
+    @task
+    def get_most_recent_auxtel_table(self) -> None:
+        self.client.get("summit-usdf/auxtel")
+
+
+class RubinTVWebsocketTester(SocketIOUser):
+    wait_time = between(1, 3)  # Optional: Adjust the wait time between tasks
+
+    def on_start(self) -> None:
+        """Initialize any necessary variables here"""
+        self.client_id: None | str = None
+
+    @task
+    def connect_disconnect(self) -> None:
+        local_url = "ws://localhost:8000/rubintv/ws/data/"
+
+        self.connect(local_url)
+
+        # Wait until the client_id is received
+        while not self.client_id:
+            time.sleep(0.1)
+
+        print(f"Connected with client ID #{self.client_id}")
+
+        # Randomly decide whether to disconnect
+        if random.random() < 0.2:  # 20% chance to disconnect unexpectedly
+            print("Closing connection unexpectedly...")
+            self.stop(force=True)
+            return  # Stop execution of this task
+
+        # Otherwise, continue with normal operation
+        message = json.dumps(
+            {
+                "clientID": self.client_id,
+                "messageType": "service",
+                "message": "camera base-usdf/fake_auxtel",
+            }
+        )
+        print(f"Sending message: {message}")
+        self.send(body=message, name="send_service_request")
+
+    def on_message(self, message: str) -> None:
+        print(f"Received message: {message}")
+        if not self.client_id:
+            self.client_id = message  # Assume the message is the client ID
+
+    def on_stop(self) -> None:
+        """Disconnect cleanly if not already disconnected"""
+        if self.client_id:
+            self.stop()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
+        "node": "^20.16.0",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -6722,6 +6723,26 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/node": {
+      "version": "20.16.0",
+      "resolved": "https://registry.npmjs.org/node/-/node-20.16.0.tgz",
+      "integrity": "sha512-NNbwzbXNi1MBoLYZAKVig2ICuCH6Wueke3zrsldpjtrSkL6QqBDhiZeBFOi19mj9kxeEPKldjHfem0rnK8OKrw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-bin-setup": "^1.0.0"
+      },
+      "bin": {
+        "node": "bin/node"
+      },
+      "engines": {
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/node-bin-setup": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+      "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
     },
     "node_modules/node-forge": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
+    "node": "^20.16.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -1,6 +1,6 @@
+from asyncio import sleep
 from time import time
 from typing import AsyncGenerator
-from asyncio import sleep
 
 from lsst.ts.rubintv.background.background_helpers import get_next_previous_from_table
 from lsst.ts.rubintv.config import rubintv_logger

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -1,4 +1,3 @@
-import asyncio
 from time import time
 from typing import AsyncGenerator
 
@@ -101,8 +100,6 @@ class CurrentPoller:
                         break
                 t_dur = time() - t_start
                 logger.info("Current - time taken:", time=t_dur)
-                await asyncio.sleep(1)
-                logger.info("CurrentPoller running...")
             except Exception:
                 logger.exception("Caught exception during poll for data")
 

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -1,4 +1,5 @@
 import asyncio
+from time import time
 from typing import AsyncGenerator
 
 from lsst.ts.rubintv.background.background_helpers import get_next_previous_from_table
@@ -61,6 +62,7 @@ class CurrentPoller:
 
     async def poll_buckets_for_todays_data(self, test_day: str = "") -> None:
         while True:
+            t_start = time()
             try:
                 if self._current_day_obs != get_current_day_obs():
                     logger.info(
@@ -97,6 +99,8 @@ class CurrentPoller:
                     self._test_iterations -= 1
                     if self._test_iterations <= 0:
                         break
+                t_dur = time() - t_start
+                logger.info("Current - time taken:", time=t_dur)
                 await asyncio.sleep(1)
                 logger.info("CurrentPoller running...")
             except Exception:

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -14,8 +14,8 @@ from lsst.ts.rubintv.models.models import (
 from lsst.ts.rubintv.models.models import ServiceMessageTypes as Service
 from lsst.ts.rubintv.models.models import get_current_day_obs
 from lsst.ts.rubintv.models.models_helpers import (
+    all_objects_to_events,
     make_table_from_event_list,
-    objects_to_events,
     objects_to_ngt_report_data,
 )
 from lsst.ts.rubintv.s3client import S3Client
@@ -110,7 +110,7 @@ class CurrentPoller:
             loc_cam not in self._objects or objects != self._objects[loc_cam]
         ):
             self._objects[loc_cam] = objects
-            events = await objects_to_events(objects)
+            events = await all_objects_to_events(objects)
             self._events[loc_cam] = events
             await self.update_channel_events(events, loc_cam, camera)
 

--- a/python/lsst/ts/rubintv/background/historicaldata.py
+++ b/python/lsst/ts/rubintv/background/historicaldata.py
@@ -148,10 +148,10 @@ class HistoricalPoller:
         await self.download_and_store_metadata(locname, metadata_objs)
 
         self._nr_metadata[locname] = await objects_to_ngt_report_data(n_report_objs)
-        for events_batch in objects_to_events(event_objs):
+        async for events_batch in objects_to_events(event_objs):
             await self.store_events(events_batch, locname)
             await self.compress_events()
-            del self._temp_events
+            self._temp_events = {}
 
     async def compress_events(self) -> None:
         t = time()

--- a/python/lsst/ts/rubintv/background/historicaldata.py
+++ b/python/lsst/ts/rubintv/background/historicaldata.py
@@ -148,16 +148,16 @@ class HistoricalPoller:
         await self.download_and_store_metadata(locname, metadata_objs)
 
         self._nr_metadata[locname] = await objects_to_ngt_report_data(n_report_objs)
-        events = await objects_to_events(event_objs)
-        await self.store_events(events, locname)
-        await self.compress_events()
+        for events_batch in objects_to_events(event_objs):
+            await self.store_events(events_batch, locname)
+            await self.compress_events()
+            del self._temp_events
 
     async def compress_events(self) -> None:
         t = time()
         for storage_key, events in self._temp_events.items():
             compressed = zlib.compress(pickle.dumps(events))
             self._events[storage_key] = compressed
-        self._temp_events = {}
         dur = time() - t
         logger.info("Compression took:", storage_key=storage_key, dur=dur)
 

--- a/python/lsst/ts/rubintv/background/historicaldata.py
+++ b/python/lsst/ts/rubintv/background/historicaldata.py
@@ -164,7 +164,7 @@ class HistoricalPoller:
     async def store_events(self, events: list[Event], locname: str) -> None:
         logger.info("starting store_events")
         for event in events:
-            storage_key = await self.storage_key_for_event(event, locname)
+            storage_key = f"{locname}/{event.camera_name}"
             if storage_key not in self._temp_events:
                 self._temp_events[storage_key] = []
             self._temp_events[storage_key].append(event)
@@ -184,9 +184,6 @@ class HistoricalPoller:
             if self._calendar[loc_cam][year][month].get(day, 0) <= seq_num:
                 self._calendar[loc_cam][year][month][day] = seq_num
         logger.info("ending store_events")
-
-    async def storage_key_for_event(self, event: Event, locname: str) -> str:
-        return f"{locname}/{event.camera_name}"
 
     async def download_and_store_metadata(
         self, locname: str, metadata_objs: list[dict[str, str]]

--- a/python/lsst/ts/rubintv/handlers/api.py
+++ b/python/lsst/ts/rubintv/handlers/api.py
@@ -149,7 +149,7 @@ async def get_current_channel_event(
         if not event:
             historical: HistoricalPoller = request.app.state.historical
             if await historical.is_busy():
-                raise HTTPException(421, "Historical data is being processed")
+                raise HTTPException(423, "Historical data is being processed")
             event = await historical.get_most_recent_event(location, camera, channel)
             if not event:
                 return None

--- a/python/lsst/ts/rubintv/handlers/handlers_helpers.py
+++ b/python/lsst/ts/rubintv/handlers/handlers_helpers.py
@@ -105,14 +105,14 @@ async def get_current_night_report_payload(
 
 
 async def try_historical_call(
-    async_func: Callable, *args: Any, **kwargs: Any
+    async_func: Callable, is_busy_default: Any = None, *args: Any, **kwargs: Any
 ) -> tuple[Any, bool]:
     try:
         result = await async_func(*args, **kwargs)
         return result, False
     except HTTPException as e:
         if e.status_code == 423:
-            return None, True
+            return is_busy_default, True
         else:
             raise e
 

--- a/python/lsst/ts/rubintv/handlers/pages.py
+++ b/python/lsst/ts/rubintv/handlers/pages.py
@@ -48,7 +48,6 @@ async def get_home(
     request: Request,
 ) -> Response:
     """GET ``/rubintv/`` (the app's external root)."""
-    # logger.info("Request for the app home page")
     locations: list[Location] = request.app.state.models.locations
     if len(locations) < 2:
         location = locations[0]
@@ -354,7 +353,7 @@ async def get_historical_night_report_page(
             "location": location,
             "camera": camera.model_dump(),
             "date": day_obs,
-            "night_report": (night_report.model_dump()),
+            "night_report": night_report.model_dump(),
             "historical_busy": historical_busy,
             "title": title,
         },

--- a/python/lsst/ts/rubintv/handlers/pages.py
+++ b/python/lsst/ts/rubintv/handlers/pages.py
@@ -48,7 +48,7 @@ async def get_home(
     request: Request,
 ) -> Response:
     """GET ``/rubintv/`` (the app's external root)."""
-    logger.info("Request for the app home page")
+    # logger.info("Request for the app home page")
     locations: list[Location] = request.app.state.models.locations
     if len(locations) < 2:
         location = locations[0]

--- a/python/lsst/ts/rubintv/handlers/pages.py
+++ b/python/lsst/ts/rubintv/handlers/pages.py
@@ -336,6 +336,7 @@ async def get_historical_night_report_page(
         camera_name=camera_name,
         date_str=date_str,
         request=request,
+        # default return is empty night report
         is_busy_default=NightReport(),
     )
 
@@ -353,9 +354,7 @@ async def get_historical_night_report_page(
             "location": location,
             "camera": camera.model_dump(),
             "date": day_obs,
-            "night_report": (
-                night_report.model_dump() if night_report is not None else {}
-            ),
+            "night_report": (night_report.model_dump()),
             "historical_busy": historical_busy,
             "title": title,
         },

--- a/python/lsst/ts/rubintv/handlers/pages.py
+++ b/python/lsst/ts/rubintv/handlers/pages.py
@@ -332,10 +332,11 @@ async def get_historical_night_report_page(
     night_report: NightReport
     night_report, historical_busy = await try_historical_call(
         get_night_report_for_date,
-        location_name,
-        camera_name,
-        date_str,
-        request,
+        location_name=location_name,
+        camera_name=camera_name,
+        date_str=date_str,
+        request=request,
+        is_busy_default=NightReport(),
     )
 
     title = build_title(
@@ -352,7 +353,9 @@ async def get_historical_night_report_page(
             "location": location,
             "camera": camera.model_dump(),
             "date": day_obs,
-            "night_report": night_report.model_dump(),
+            "night_report": (
+                night_report.model_dump() if night_report is not None else {}
+            ),
             "historical_busy": historical_busy,
             "title": title,
         },
@@ -382,7 +385,11 @@ async def get_specific_channel_event_page(
     if channel:
         channel_title = channel.title
         next_prev, historical_busy = await try_historical_call(
-            get_prev_next_event, location, camera, event, request
+            get_prev_next_event,
+            location=location,
+            camera=camera,
+            event=event,
+            request=request,
         )
         if historical_busy:
             next_prev = {}

--- a/python/lsst/ts/rubintv/models/models_helpers.py
+++ b/python/lsst/ts/rubintv/models/models_helpers.py
@@ -96,7 +96,7 @@ def process_batch(batch: list[dict]) -> list[Event]:
 async def all_objects_to_events(objects: list[dict]) -> list[Event]:
     events = []
     async for events_batch in objects_to_events(objects):
-        events.append(events_batch)
+        events.extend(events_batch)
     return events
 
 

--- a/python/lsst/ts/rubintv/templates/camera_parts/calendar.jinja
+++ b/python/lsst/ts/rubintv/templates/camera_parts/calendar.jinja
@@ -1,4 +1,5 @@
 {% set year_to_display = calendar|last %}
+{% set camera_url = url_for('camera', location_name=location.name, camera_name=camera.name) %}
 {% if camera.name == "allsky" %}
   {% set no_total_seq = True %}
 {% endif %}
@@ -42,7 +43,7 @@
                   {% if day in calendar[year][month]|list %}
                     {% set date_str = "{:04}-{:02}-{:02}".format(year, month, day) %}
                     <a  class="day obs"
-                        href="{{ url_for('camera_for_date', location_name=location.name, camera_name=camera.name, date_str=date_str) }}">
+                        href="{{ camera_url }}/date/{{ date_str }}">
                       <span class="day_num">{{ day }}</span>
                       {% if not no_total_seq %}
                         <span class="num_evs">({{ calendar[year][month][day] }})</span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ moto
 pytest_asyncio
 websocket-client
 beautifulsoup4
+py-spy
+locust
+locust_plugins

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -73,8 +73,10 @@ async def test_current_channels(
     client, app, mocker = mocked_client
 
     cp: CurrentPoller = app.state.current_poller
+    hp: HistoricalPoller = app.state.historical
     cp.test_mode = True
-    while cp.completed_first_poll is not True:
+    hp.test_mode = True
+    while cp.completed_first_poll is False or hp._have_downloaded is False:
         await asyncio.sleep(0.1)
 
     for location in m.locations:


### PR DESCRIPTION
Fixes blocking operations like a very inefficient listcomp and uses asyncronous batch processing for converting, storing and compressing data objects.

The result aims to remove large blocks from the main thread for better app responsiveness.

It also fixes a case where requesting a night report during historical polling would cause a 500 error.
 