### PR TITLE
DM-45327: Handle empty historical days for cameras more elegantly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
   "uvicorn[standard]",
   "pydantic_settings",
   # Other dependencies.
-  "safir>=3.4.0",
   "boto3",
   "jinja2",
   "websockets",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # when using the Dockerfile on the root folder.
 setuptools_scm
 asgi_lifespan
+structlog
 boto3
 fastapi
 httpx

--- a/src/js/components/TableApp.js
+++ b/src/js/components/TableApp.js
@@ -69,6 +69,11 @@ export default function TableApp ({ camera, initialDate, initialChannelData, ini
     }
   }, [date]) // Only reattach the event listener if the date changes
 
+  if (Object.entries(metadata).length + Object.entries(channelData).length == 0) {
+    return (
+      <h3>There is no data for this day</h3>
+    )
+  }
   return (
     <div className="table-container">
       <div className="above-table-sticky">

--- a/src/js/components/TableView.js
+++ b/src/js/components/TableView.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { indicatorForAttr, _elWithClass, _elWithAttrs, replaceInString, _getById } from '../modules/utils'
 import { metadatumType } from './componentPropTypes'


### PR DESCRIPTION
Displays 'no data for this day' message instead of an empty table.

Also remove `safir` from `pyproject.toml`.