### PR TITLE
DM-45331: Manage cases when yesterday's movie needs to be picked up immediately

### DIFF
--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -119,6 +119,10 @@ class CurrentPoller:
 
                     # Only look for yesterday's missing per day data if nothing
                     # yet found for today.
+
+                    # TODO: This is too broad- check for data from each camera
+                    # separately
+
                     if not data_for_today_found:
                         await self.poll_for_yesterdays_per_day(location)
 

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -92,8 +92,8 @@ class CurrentPoller:
                 if self._current_day_obs != get_current_day_obs():
                     await self.check_for_empty_per_day_channels()
                     await self.clear_todays_data()
-                    day_obs = self._current_day_obs = get_current_day_obs()
                     data_for_today_found = False
+                day_obs = self._current_day_obs = get_current_day_obs()
 
                 for location in self.locations:
                     client = self._s3clients[location.name]

--- a/python/lsst/ts/rubintv/handlers/api.py
+++ b/python/lsst/ts/rubintv/handlers/api.py
@@ -32,7 +32,7 @@ async def historical_reset(request: Request) -> None:
     historical: HistoricalPoller = request.app.state.historical
     await historical.trigger_reload_everything()
     current: CurrentPoller = request.app.state.current_poller
-    await current.clear_all_data()
+    await current.clear_todays_data()
 
 
 @api_router.get("/{location_name}", response_model=Location)

--- a/python/lsst/ts/rubintv/handlers/websocket.py
+++ b/python/lsst/ts/rubintv/handlers/websocket.py
@@ -14,7 +14,7 @@ from lsst.ts.rubintv.handlers.websockets_clients import (
     websocket_to_client,
 )
 from lsst.ts.rubintv.models.models import Camera, Location
-from lsst.ts.rubintv.models.models import ServiceMessageTypes as Service
+from lsst.ts.rubintv.models.models import ServiceMessageTypes as MessageType
 from lsst.ts.rubintv.models.models_helpers import find_first
 
 data_ws_router = APIRouter()
@@ -77,7 +77,7 @@ async def data_websocket(
                     historical_busy = await websocket.app.state.historical.is_busy()
                     await websocket.send_json(
                         {
-                            "dataType": Service.HISTORICAL_STATUS.value,
+                            "dataType": MessageType.HISTORICAL_STATUS.value,
                             "payload": historical_busy,
                         }
                     )

--- a/python/lsst/ts/rubintv/models/models.py
+++ b/python/lsst/ts/rubintv/models/models.py
@@ -357,5 +357,6 @@ class ServiceMessageTypes(Enum):
     CAMERA_TABLE: str = "channelData"
     CAMERA_METADATA: str = "metadata"
     CAMERA_PER_DAY: str = "perDay"
+    CAMERA_PD_BACKDATED: str = "perDayBackdated"
     NIGHT_REPORT: str = "nightReport"
     HISTORICAL_STATUS: str = "historicalStatus"

--- a/tests/background/currentpoller_test.py
+++ b/tests/background/currentpoller_test.py
@@ -93,7 +93,7 @@ async def test_clear_all_data(current_poller: CurrentPoller) -> None:
     assert current_poller.completed_first_poll is True
     assert current_poller._objects != {}
 
-    await current_poller.clear_all_data()
+    await current_poller.clear_todays_data()
     assert current_poller._objects == {}
     assert current_poller._events == {}
     assert current_poller._metadata == {}
@@ -108,7 +108,7 @@ async def test_clear_all_data(current_poller: CurrentPoller) -> None:
 async def test_process_channel_objects(
     current_poller: CurrentPoller, rubin_data_mocker: RubinDataMocker
 ) -> None:
-    await current_poller.clear_all_data()
+    await current_poller.clear_todays_data()
 
     camera, location = await get_test_camera_and_location()
     loc_cam = f"{location.name}/{camera.name}"
@@ -152,7 +152,7 @@ async def test_update_channel_events(
         loc_cam = f"{location.name}/{camera.name}"
         events = rubin_data_mocker.events[loc_cam]
 
-        await current_poller.clear_all_data()
+        await current_poller.clear_todays_data()
         assert current_poller._most_recent_events == {}
         loc_cam = f"{location.name}/{camera.name}"
         await current_poller.update_channel_events(events, loc_cam, camera)

--- a/tests/background/currentpoller_test.py
+++ b/tests/background/currentpoller_test.py
@@ -37,7 +37,7 @@ async def test_poll_buckets_for_todays_data(
             return_value="2024-03-28",
         ) as mock_day_obs,
         patch(
-            "lsst.ts.rubintv.background.currentpoller.CurrentPoller.clear_all_data",
+            "lsst.ts.rubintv.background.currentpoller.CurrentPoller.clear_todays_data",
             new_callable=AsyncMock,
         ),
         patch(
@@ -87,7 +87,7 @@ async def test_poll_buckets_for_today_process_and_store_seq_events(
 
 
 @pytest.mark.asyncio
-async def test_clear_all_data(current_poller: CurrentPoller) -> None:
+async def test_clear_todays_data(current_poller: CurrentPoller) -> None:
     await current_poller.poll_buckets_for_todays_data()
 
     assert current_poller.completed_first_poll is True
@@ -215,6 +215,13 @@ async def test_day_rollover(
         await current_poller.poll_buckets_for_todays_data()
 
         assert mock_day_obs
+
+
+@pytest.mark.asyncio
+async def test_pick_up_yesterdays_movie(
+    current_poller: CurrentPoller, rubin_data_mocker: RubinDataMocker
+) -> None:
+    pass
 
 
 async def get_test_camera_and_location() -> tuple[Camera, Location]:

--- a/tests/background/currentpoller_test.py
+++ b/tests/background/currentpoller_test.py
@@ -79,7 +79,6 @@ async def test_poll_buckets_for_today_process_and_store_seq_events(
     await current_poller.poll_buckets_for_todays_data()
 
     mocked_objs_keys = rubin_data_mocker.events.keys()
-    print(mocked_objs_keys)
 
     # make sure the keys for the location/cameras match up
     current_keys = sorted([k for k in current_poller._events.keys()])

--- a/tests/mockdata.py
+++ b/tests/mockdata.py
@@ -48,9 +48,9 @@ class RubinDataMocker:
         self.s3_required = s3_required
         self.day_obs = day_obs
         self.location_channels: dict[str, list[Channel]] = {}
-        self.seq_objs: dict[str, list[dict[str, str]]] = {}
         self.empty_channel: dict[str, str] = {}
         self.events: dict[str, list[Event]] = {}
+        self.seq_objs: dict[str, list[dict[str, str]]] = {}
         self.metadata: dict[str, dict[str, str]] = {}
         self.mock_up_data()
 
@@ -78,7 +78,6 @@ class RubinDataMocker:
 
         for location in self._locations:
             loc_name = location.name
-            self.events[loc_name] = []
             self.location_channels[loc_name] = []
             groups = location.camera_groups.values()
             camera_names = list(chain(*groups))
@@ -97,7 +96,9 @@ class RubinDataMocker:
                     metadata = self.add_camera_metadata(location, camera)
                     self.metadata[loc_cam] = metadata
 
-    def add_seq_objs(self, location: Location, camera: Camera) -> None:
+    def add_seq_objs(
+        self, location: Location, camera: Camera, include_empty_channel: bool = True
+    ) -> None:
         """
         Generate mock channel objects and an empty channel string for a given
         camera and location.
@@ -117,44 +118,49 @@ class RubinDataMocker:
             A tuple containing a list of mock channel dictionaries and an
             updated empty channel string.
         """
-
-        channel_data: list[dict[str, str]] = []
         loc_cam = f"{location.name}/{camera.name}"
-        iterations = 8
 
         empty_channel = ""
-        seq_chans = [chan.name for chan in camera.seq_channels()]
-        if seq_chans:
-            empty_channel = random.choice(seq_chans)
+        if include_empty_channel:
+            seq_chans = [chan.name for chan in camera.seq_channels()]
+            if seq_chans:
+                empty_channel = random.choice(seq_chans)
 
         for channel in camera.channels:
-            loc_cam_chan = f"{loc_cam}/{channel.name}"
-            start = self.last_seq.get(loc_cam_chan, self.FIRST_SEQ)
-
             if empty_channel == channel.name:
                 self.empty_channel[loc_cam] = empty_channel
                 continue
+            self.add_seq_objs_for_channel(location, camera, channel, 2)
 
-            for index in range(start, start + iterations):
-                seq_num = f"{index:06}"
+    def add_seq_objs_for_channel(
+        self, location: Location, camera: Camera, channel: Channel, num_objs: int
+    ) -> None:
+        channel_data: list[dict[str, str]] = []
+        loc_cam = f"{location.name}/{camera.name}"
+        loc_cam_chan = f"{location.name}/{camera.name}/{channel.name}"
+        start = self.last_seq.get(loc_cam_chan, self.FIRST_SEQ)
 
-                if channel.per_day and index == start + iterations - 1:
-                    seq_num = random.choice((seq_num, "final"))
+        for index in range(start, start + num_objs):
+            seq_num = f"{index:06}"
 
-                event_obj = self.generate_event(
-                    location.bucket_name, camera.name, channel.name, seq_num
-                )
+            if channel.per_day and index == start + num_objs - 1:
+                seq_num = random.choice((seq_num, "final"))
 
-                channel_data.append(event_obj)
-            self.last_seq[loc_cam_chan] = index
+            event_obj = self.generate_event(
+                location.bucket_name, camera.name, channel.name, seq_num
+            )
+
+            channel_data.append(event_obj)
+        self.last_seq[loc_cam_chan] = index
 
         # store the objects for testing against
-        if loc_cam in self.seq_objs:
+        event = self.dicts_to_events(channel_data)
+        if loc_cam in self.events:
+            self.events[loc_cam].extend(event)
             self.seq_objs[loc_cam].extend(channel_data)
-            self.events[loc_cam].extend(self.dicts_to_events(channel_data))
         else:
+            self.events[loc_cam] = event
             self.seq_objs[loc_cam] = channel_data
-            self.events[loc_cam] = self.dicts_to_events(channel_data)
 
     def generate_event(
         self, bucket_name: str, camera_name: str, channel_name: str, seq_num: str
@@ -172,6 +178,28 @@ class RubinDataMocker:
         if hash is None:
             hash = str(random.getrandbits(128))
         return {"key": key, "hash": hash}
+
+    def delete_channel_events(
+        self, location: Location, camera: Camera, channel: Channel
+    ) -> None:
+        bucket_name = location.bucket_name
+        loc_cam = f"{location.name}/{camera.name}"
+        loc_cam_chan = f"{loc_cam}/{channel.name}"
+        events = self.events.get(loc_cam, [])
+        chan_evs = [ev for ev in events if ev.channel_name == channel.name]
+
+        for ev in chan_evs:
+            self.events[loc_cam].remove(ev)
+            if self.s3_required:
+                res = self.s3_client.delete_object(Bucket=bucket_name, Key=ev.key)
+                print(f"Attempted to delete object: {ev.key}, result is: {res}")
+
+        if loc_cam_chan in self.last_seq:
+            del self.last_seq[loc_cam_chan]
+        if self.empty_channel[loc_cam] == channel.name:
+            del self.empty_channel[loc_cam]
+        if channel in self.location_channels[location.name]:
+            self.location_channels[location.name].remove(channel)
 
     def dicts_to_events(self, channel_dicts: list[dict[str, str]]) -> list[Event]:
         """

--- a/tests/mockdata.py
+++ b/tests/mockdata.py
@@ -218,9 +218,11 @@ class RubinDataMocker:
         events = [Event(**cd) for cd in channel_dicts]
         return events
 
-    async def get_mocked_seq_events(self, location: Location) -> list[Event]:
+    def get_mocked_events(
+        self, location: Location, camera: Camera, channel: Channel
+    ) -> list[Event]:
         """
-        Asynchronously retrieve sequence events for a given location.
+        Retrieve events for a given location.
 
         Parameters
         ----------
@@ -232,13 +234,11 @@ class RubinDataMocker:
         list[Event]
             A list of Event objects representing sequence events.
         """
-        events = self.events.get(location.name)
-        if events is None:
-            return []
-        channels = self.location_channels[location.name]
-        seq_chan_names = [c for c in channels if not c.per_day]
-        seq_chan_events = [e for e in events if e.channel_name in seq_chan_names]
-        return seq_chan_events
+        loc_cam = f"{location.name}/{camera.name}"
+        events = [
+            e for e in self.events.get(loc_cam, []) if e.channel_name in channel.name
+        ]
+        return events
 
     def add_camera_metadata(self, location: Location, camera: Camera) -> dict[str, str]:
         """


### PR DESCRIPTION
The poller for the current objects only looks in the bucket for objects prefixed with the current day so if a movie is generated the day after, it won't be picked up until the daily historical poll has been completed. 
This PR adds a mechanism whereby, if no more current data has been taken for the new day, the poller will look for 'per day' data (e.g. movies) to add to the previous day's page without the need for the client to refresh the page.