### PR TITLE
DM-47867: Add ability for metadata to provide symbols for empty channel cells

### DIFF
--- a/src/js/components/TableApp.js
+++ b/src/js/components/TableApp.js
@@ -148,7 +148,9 @@ function getAllColumnNamesFromMetadata(metadata) {
     .map((obj) => Object.keys(obj))
     .flat()
   // filter out the indicators (first char is '_')
-  return allCols.filter((el) => el[0] !== "_")
+  // and the replacement strings for empty channels
+  // (first char is '@')
+  return allCols.filter((el) => el[0] !== "_" || el[0] !== "@")
 }
 
 function getTableColumnWidths() {

--- a/src/js/components/TableView.js
+++ b/src/js/components/TableView.js
@@ -60,7 +60,7 @@ MetadataCell.propTypes = {
 }
 
 // Component for individual channel cell
-function ChannelCell({ event, chanName, chanColour }) {
+function ChannelCell({ event, chanName, chanColour, noEventReplacement }) {
   const eventURL = window.APP_DATA.eventURL
   return (
     <td className="grid-cell">
@@ -71,6 +71,9 @@ function ChannelCell({ event, chanName, chanColour }) {
           href={`${eventURL}?key=${event.key}`}
         />
       )}
+      {!event && noEventReplacement && (
+        <p className="center-text cell-emoji">{noEventReplacement}</p>
+      )}
     </td>
   )
 }
@@ -79,6 +82,7 @@ ChannelCell.propTypes = {
   eventURL: PropTypes.string,
   chanName: PropTypes.string,
   chanColour: PropTypes.string,
+  noEventReplacement: PropTypes.string,
 }
 
 // Component for individual table row
@@ -91,6 +95,14 @@ function TableRow({
   metadataRow,
 }) {
   const dayObs = window.APP_DATA.date.replaceAll("-", "")
+
+  const noEventReplacements = channels.reduce((obj, chan) => {
+    const chanReplace = metadataRow.hasOwnProperty("@" + chan.name)
+      ? metadataRow["@" + chan.name]
+      : null
+    return { ...obj, [chan.name]: chanReplace }
+  }, {})
+
   const metadataCells = metadataColumns.map((md) => {
     const indicator = indicatorForAttr(metadataRow, md.name)
     return {
@@ -100,6 +112,7 @@ function TableRow({
       indicator,
     }
   })
+
   return (
     <tr>
       <td className="grid-cell seq" id={`seqNum-${seqNum}`}>
@@ -130,6 +143,7 @@ function TableRow({
           event={channelRow[chan.name]}
           chanName={chan.name}
           chanColour={chan.colour}
+          noEventReplacement={noEventReplacements[chan.name]}
         />
       ))}
       {metadataCells.map((md) => (

--- a/src/js/components/TableView.js
+++ b/src/js/components/TableView.js
@@ -96,6 +96,8 @@ function TableRow({
 }) {
   const dayObs = window.APP_DATA.date.replaceAll("-", "")
 
+  // Entries in metadata keyed `"@{channel_name}"` will have their
+  // values show up in the table instead of a blank space.
   const noEventReplacements = channels.reduce((obj, chan) => {
     const chanReplace = metadataRow.hasOwnProperty("@" + chan.name)
       ? metadataRow["@" + chan.name]

--- a/src/js/components/TableView.js
+++ b/src/js/components/TableView.js
@@ -99,9 +99,7 @@ function TableRow({
   // Entries in metadata keyed `"@{channel_name}"` will have their
   // values show up in the table instead of a blank space.
   const noEventReplacements = channels.reduce((obj, chan) => {
-    const chanReplace = metadataRow.hasOwnProperty("@" + chan.name)
-      ? metadataRow["@" + chan.name]
-      : null
+    const chanReplace = metadataRow["@" + chan.name] ?? null
     return { ...obj, [chan.name]: chanReplace }
   }, {})
 

--- a/src/js/modules/utils.js
+++ b/src/js/modules/utils.js
@@ -138,7 +138,6 @@ export function getStrHashCode(str) {
 }
 
 export const decodeUnpackWSPayload = (compressed) => {
-  const timeNow = Date.now()
   let data
   try {
     // Decode Base64 string to Uint8Array
@@ -161,8 +160,6 @@ export const decodeUnpackWSPayload = (compressed) => {
       error: "Couldn't decompress payload",
     }
   }
-  const elapsed = Date.now() - timeNow
-  console.log("time taken:", elapsed)
   return data
 }
 

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -292,7 +292,8 @@ section
 	vertical-align: middle
 	height: 42px
 	box-sizing: border-box
-
+	&.seq
+		text-align: right
 
 .copy-to-cb
 	padding-left: 0.7em

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -21,6 +21,9 @@
 	margin-top: -7vh
 	margin-bottom: -9vh
 
+.center-text
+	text-align: center
+
 a
 	text-decoration: none
 	display: inline-block
@@ -292,9 +295,6 @@ section
 
 
 .copy-to-cb
-	display: flex
-	justify-content: center
-	align-items: center
 	padding-left: 0.7em
 	padding-right: 0.7em
 
@@ -406,6 +406,9 @@ section
 		content: ":"
 		padding-right: 2em
 
+.cell-emoji
+	font-size: 2.2em
+	opacity: 0.5
 
 .admin-access
 	margin-top: 3em


### PR DESCRIPTION
For e.g. if the metadata for a row contains `"@calexp_mosaic": "🍩"` and if the mentioned channel has no event for that row, the string (emoji, character or symbol) will be entered instead of an empty cell:
![screenshot_2024-12-01_at_15 49 02](https://github.com/user-attachments/assets/a52e04a6-3ba5-487e-9476-026d61be2b17)
