### PR TITLE
DM-50971: Improve event page navigation

### DIFF
--- a/python/lsst/ts/rubintv/background/background_helpers.py
+++ b/python/lsst/ts/rubintv/background/background_helpers.py
@@ -34,13 +34,14 @@ async def get_next_previous_from_table(
         return (None, None)
 
     # creates a 'None' padded list of seq. nums
-    padded_seqs = [None, *chan_table.keys(), None]
+    all_seqs = sorted(set(chan_table.keys() | {event.seq_num_force_int()}))
+    padded_seqs = [None, *all_seqs, None]
 
     # find the index of event's seq num in that padded list
     index = padded_seqs.index(event.seq_num_force_int())
 
-    next_seq = padded_seqs[index - 1]
-    prev_seq = padded_seqs[index + 1]
+    next_seq = padded_seqs[index + 1]
+    prev_seq = padded_seqs[index - 1]
 
     nxt_prv = (
         chan_table.get(next_seq),  # type: ignore

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -599,7 +599,5 @@ class CurrentPoller:
         loc_cam = f"{location_name}/{camera_name}"
         events = self._events.get(loc_cam, [])
         relevant_events = [e for e in events if e.seq_num == seq_num]
-        if not relevant_events:
-            return []
         chan_names = [event.channel_name for event in relevant_events]
         return chan_names

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -551,3 +551,28 @@ class CurrentPoller:
                 ):
                     yield MessageType.LATEST_METADATA, (latest_metadata)
                 yield MessageType.DAY_CHANGE, "from current poller"
+
+    async def get_all_channel_names_for_seq_num(
+        self, location_name: str, camera_name: str, seq_num: int
+    ) -> list[str]:
+        """Get all channel names for a given sequence number.
+        Parameters
+        ----------
+        location_name : `str`
+            The name of the location.
+        camera_name : `str`
+            The name of the camera.
+        seq_num : `int`
+            The sequence number.
+        Returns
+        -------
+        `list` [`str`]
+            A list of channel names for the given sequence number.
+        """
+        loc_cam = f"{location_name}/{camera_name}"
+        events = self._events.get(loc_cam, [])
+        relevant_events = [e for e in events if e.seq_num == seq_num]
+        if not relevant_events:
+            return []
+        chan_names = [event.channel_name for event in relevant_events]
+        return chan_names

--- a/python/lsst/ts/rubintv/background/currentpoller.py
+++ b/python/lsst/ts/rubintv/background/currentpoller.py
@@ -250,6 +250,15 @@ class CurrentPoller:
                     chan_lookup,
                     {"next": None, "prev": prev},
                 )
+                channel_names = await self.get_all_channel_names_for_seq_num(
+                    location.name, camera.name, current_event.seq_num_force_int()
+                )
+                await notify_ws_clients(
+                    Service.CHANNEL,
+                    MessageType.ALL_CHANNELS,
+                    chan_lookup,
+                    channel_names,
+                )
 
     async def sieve_out_metadata(
         self,
@@ -544,6 +553,10 @@ class CurrentPoller:
                 if event is not None:
                     _, prev = await self.get_next_prev_event(location.name, event)
                     yield MessageType.PREV_NEXT, {"next": None, "prev": prev}
+                    channel_names = await self.get_all_channel_names_for_seq_num(
+                        location.name, camera.name, event.seq_num_force_int()
+                    )
+                    yield MessageType.ALL_CHANNELS, channel_names
 
                 if latest_metadata := await self.get_latest_metadata(
                     location.name, camera

--- a/python/lsst/ts/rubintv/background/historicaldata.py
+++ b/python/lsst/ts/rubintv/background/historicaldata.py
@@ -430,3 +430,35 @@ class HistoricalPoller:
         """
         loc_cam = f"{location.name}/{camera.name}"
         return self._calendar.get(loc_cam, {})
+
+    async def get_all_channel_names_for_date_and_seq_num(
+        self, location: Location, camera: Camera, date: str, seq_num: int
+    ) -> list[str]:
+        """Returns a list of Events for the given date and seq_num.
+
+        Parameters
+        ----------
+        camera : `Camera`
+            The given Camera.
+        date : `str`
+            The given date.
+        seq_num : `int`
+            The given sequence number.
+
+        Returns
+        -------
+        chan_names : `list` [`str`]
+            A list of channel names for the given date and seq_num.
+        """
+        loc_cam = f"{location.name}/{camera.name}"
+        compressed = self._compressed_events.get(loc_cam, None)
+        if compressed is None:
+            return []
+        events: list[Event] = pickle.loads(zlib.decompress(compressed))
+        relevant_events = [
+            e for e in events if e.day_obs == date and e.seq_num == seq_num
+        ]
+        chan_names = [e.channel_name for e in relevant_events]
+        if not chan_names:
+            return []
+        return chan_names

--- a/python/lsst/ts/rubintv/background/historicaldata.py
+++ b/python/lsst/ts/rubintv/background/historicaldata.py
@@ -459,6 +459,4 @@ class HistoricalPoller:
             e for e in events if e.day_obs == date and e.seq_num == seq_num
         ]
         chan_names = [e.channel_name for e in relevant_events]
-        if not chan_names:
-            return []
         return chan_names

--- a/python/lsst/ts/rubintv/handlers/handlers_helpers.py
+++ b/python/lsst/ts/rubintv/handlers/handlers_helpers.py
@@ -165,3 +165,29 @@ def date_validation(date_str: str) -> date:
     except ValueError:
         raise HTTPException(status_code=404, detail="Invalid date.")
     return day_obs
+
+
+async def get_all_channel_names_for_date_seq_num(
+    location: Location,
+    camera: Camera,
+    day_obs: date,
+    seq_num: int,
+    connection: HTTPConnection,
+) -> dict[str, Any]:
+    """Get all channels for a given date and sequence number."""
+    if day_obs == get_current_day_obs():
+        cp: CurrentPoller = connection.app.state.current_poller
+        channel_data = await cp.get_all_channel_names_for_seq_num(
+            location.name, camera, day_obs, seq_num
+        )
+        return channel_data
+    historical: HistoricalPoller = connection.app.state.historical
+    channel_data, _ = await try_historical_call(
+        historical.get_all_channel_names_for_date_and_seq_num,
+        [],
+        location,
+        camera,
+        day_obs,
+        seq_num,
+    )
+    return channel_data

--- a/python/lsst/ts/rubintv/handlers/handlers_helpers.py
+++ b/python/lsst/ts/rubintv/handlers/handlers_helpers.py
@@ -173,7 +173,7 @@ async def get_all_channel_names_for_date_seq_num(
     day_obs: date,
     seq_num: int,
     connection: HTTPConnection,
-) -> dict[str, Any]:
+) -> list[str]:
     """Get all channels for a given date and sequence number."""
     if day_obs == get_current_day_obs().isoformat():
         cp: CurrentPoller = connection.app.state.current_poller

--- a/python/lsst/ts/rubintv/handlers/handlers_helpers.py
+++ b/python/lsst/ts/rubintv/handlers/handlers_helpers.py
@@ -175,10 +175,10 @@ async def get_all_channel_names_for_date_seq_num(
     connection: HTTPConnection,
 ) -> dict[str, Any]:
     """Get all channels for a given date and sequence number."""
-    if day_obs == get_current_day_obs():
+    if day_obs == get_current_day_obs().isoformat():
         cp: CurrentPoller = connection.app.state.current_poller
         channel_data = await cp.get_all_channel_names_for_seq_num(
-            location.name, camera, day_obs, seq_num
+            location.name, camera.name, seq_num
         )
         return channel_data
     historical: HistoricalPoller = connection.app.state.historical

--- a/python/lsst/ts/rubintv/handlers/pages.py
+++ b/python/lsst/ts/rubintv/handlers/pages.py
@@ -14,6 +14,7 @@ from lsst.ts.rubintv.handlers.api import (
 )
 from lsst.ts.rubintv.handlers.handlers_helpers import (
     date_validation,
+    get_all_channel_names_for_date_seq_num,
     get_camera_calendar,
     get_camera_current_data,
     get_camera_events_for_date,
@@ -434,6 +435,13 @@ async def get_specific_channel_event_page(
         )
         if historical_busy:
             next_prev = {}
+        all_channel_names = await get_all_channel_names_for_date_seq_num(
+            location=location,
+            camera=camera,
+            day_obs=event.day_obs,
+            seq_num=event.seq_num,
+            connection=request,
+        )
 
     title = build_title(location.title, camera.title, channel_title, event_detail)
 
@@ -447,6 +455,7 @@ async def get_specific_channel_event_page(
             "channel": to_dict(channel),
             "event": to_dict(event),
             "prevNext": next_prev,
+            "allChannelNames": all_channel_names,
             "historicalBusy": historical_busy,
             "title": title,
         },

--- a/python/lsst/ts/rubintv/handlers/pages.py
+++ b/python/lsst/ts/rubintv/handlers/pages.py
@@ -494,12 +494,14 @@ async def get_current_channel_event_page(
             connection=request,
         )
 
-    prev_next = await get_prev_next_event(
-        location=location,
-        camera=camera,
-        event=event,
-        request=request,
-    )
+    prev_next = {}
+    if event is not None:
+        prev_next = await get_prev_next_event(
+            location=location,
+            camera=camera,
+            event=event,
+            request=request,
+        )
 
     title = build_title(location.title, camera.title, channel.title, "Current")
 

--- a/python/lsst/ts/rubintv/models/models.py
+++ b/python/lsst/ts/rubintv/models/models.py
@@ -441,6 +441,7 @@ class ServiceMessageTypes(Enum):
     NIGHT_REPORT = "nightReport"
     HISTORICAL_STATUS = "historicalStatus"
     DAY_CHANGE = "dayChange"
+    PREV_NEXT = "prevNext"
 
 
 class KeyValue(BaseModel):

--- a/python/lsst/ts/rubintv/models/models.py
+++ b/python/lsst/ts/rubintv/models/models.py
@@ -442,6 +442,7 @@ class ServiceMessageTypes(Enum):
     HISTORICAL_STATUS = "historicalStatus"
     DAY_CHANGE = "dayChange"
     PREV_NEXT = "prevNext"
+    ALL_CHANNELS = "allChannels"
 
 
 class KeyValue(BaseModel):

--- a/python/lsst/ts/rubintv/models/models_data.yaml
+++ b/python/lsst/ts/rubintv/models/models_data.yaml
@@ -126,9 +126,11 @@ cameras:
       - name: psf_shape_azel
         title: PSF shape AzEl
         colour: "#6F58E7"
+        text_colour: "#fff"
       - name: fwhm_focal_plane
         title: FWHM Focal Plane
         colour: "#6232A8"
+        text_colour: "#fff"
       - name: mount
         title: Mount torques
         colour: "#58b4e7"

--- a/python/lsst/ts/rubintv/templates/single_event.jinja
+++ b/python/lsst/ts/rubintv/templates/single_event.jinja
@@ -53,6 +53,7 @@
     window.APP_DATA.imgUrl = "{{ img_url }}";
     window.APP_DATA.videoUrl = "{{ video_url }}";
     window.APP_DATA.prevNext = {{ prevNext|tojson if prevNext else "null"}};
+    window.APP_DATA.allChannelNames = {{ allChannelNames|tojson}};
     window.APP_DATA.eventUrl = "{{ url_for('single_event', location_name=location.name, camera_name=camera.name) }}";
   </script>
 {% endif %}

--- a/src/js/components/MediaDisplay.js
+++ b/src/js/components/MediaDisplay.js
@@ -15,10 +15,11 @@ export default function MediaDisplay({
   metadata,
   eventUrl,
   prevNext,
+  allChannelNames,
   isCurrent = false,
 }) {
   const [mediaEvent, setMediaEvent] = useState(() =>
-    unifyMediaEvent(initialEvent, imgUrl, videoUrl)
+    bundleMediaEventData(initialEvent, imgUrl, videoUrl)
   )
 
   useEffect(() => {
@@ -28,7 +29,7 @@ export default function MediaDisplay({
         return
       }
       setMediaEvent({
-        ...unifyMediaEvent(event, imgUrl, videoUrl),
+        ...bundleMediaEventData(event, imgUrl, videoUrl),
       })
     }
 
@@ -51,6 +52,11 @@ export default function MediaDisplay({
         ) : (
           <PrevNext prevNext={prevNext} eventUrl={eventUrl} />
         )}
+        <OtherChannelLinks
+          allChannelNames={allChannelNames}
+          thisChannel={mediaEvent.channel_name}
+          camera={camera}
+        />
       </div>
       <a
         className="event-link"
@@ -85,6 +91,7 @@ MediaDisplay.propTypes = {
     prev: eventType,
     next: eventType,
   }),
+  allChannelNames: PropTypes.arrayOf(PropTypes.string),
   isCurrent: PropTypes.bool,
 }
 
@@ -100,7 +107,7 @@ MediaDisplay.propTypes = {
  * the source URL using the filename and base URL. The media type can be
  * either "image" or "video".
  */
-function unifyMediaEvent(mEvent, imgUrl, videoUrl) {
+function bundleMediaEventData(mEvent, imgUrl, videoUrl) {
   const { filename, ext } = mEvent
   const mediaType = getMediaType(ext)
   const url = mediaType === "video" ? videoUrl : imgUrl
@@ -111,4 +118,38 @@ function unifyMediaEvent(mEvent, imgUrl, videoUrl) {
     mediaType,
     src,
   }
+}
+
+const OtherChannelLinks = ({ allChannelNames, thisChannel, camera }) => {
+  if (!allChannelNames || allChannelNames.length === 0) {
+    return null
+  }
+  // Filter out the current channel from the list of all channels
+  const filteredChannels = allChannelNames.filter(
+    (channel) => channel !== thisChannel
+  )
+  const currentUrl = document.location.toString()
+  return (
+    <div className="other-channels">
+      {filteredChannels.map((channel) => {
+        const channelObj = camera.channels.find((chan) => chan.name === channel)
+        const chanStyle = {
+          backgroundColor: channelObj.colour,
+          color: channelObj.text_colour,
+        }
+        // Construct the URL for each channel
+        const channelUrl = currentUrl.replaceAll(thisChannel, channel)
+        return (
+          <a
+            key={channel}
+            href={channelUrl}
+            style={chanStyle}
+            className="button"
+          >
+            {channel}
+          </a>
+        )
+      })}
+    </div>
+  )
 }

--- a/src/js/components/MediaDisplay.js
+++ b/src/js/components/MediaDisplay.js
@@ -143,7 +143,7 @@ const OtherChannelLinks = ({ allChannelNames, thisChannel, camera }) => {
   )
   const currentUrl = document.location.toString()
   const buildUrl = (channelName) => {
-    if (currentUrl.endsWith(`${channelName}/current`)) {
+    if (currentUrl.endsWith(`${thisChannel}/current`)) {
       return currentUrl.replace(thisChannel, channelName)
     } else {
       return currentUrl.replace(

--- a/src/js/components/MediaDisplay.js
+++ b/src/js/components/MediaDisplay.js
@@ -42,16 +42,17 @@ export default function MediaDisplay({
     <>
       <div className="event-info">
         <h2>
-          <a href={dateUrl}>
-            <span className="media-date">{mediaEvent.day_obs}</span>
+          <a href={dateUrl} className="media-date">
+            {mediaEvent.day_obs}
           </a>
           <span className="media-seqnum">{mediaEvent.seq_num}</span>
         </h2>
-        {isCurrent ? (
+        {isCurrent && (
           <TimeSinceLastImageClock metadata={metadata} camera={camera} />
-        ) : (
-          <PrevNext prevNext={prevNext} eventUrl={eventUrl} />
         )}
+      </div>
+      <div className="event-nav">
+        <PrevNext prevNext={prevNext} eventUrl={eventUrl} />
         <OtherChannelLinks
           allChannelNames={allChannelNames}
           thisChannel={mediaEvent.channel_name}
@@ -146,7 +147,7 @@ const OtherChannelLinks = ({ allChannelNames, thisChannel, camera }) => {
             style={chanStyle}
             className="button"
           >
-            {channel}
+            {channelObj.title}
           </a>
         )
       })}

--- a/src/js/components/MediaDisplay.js
+++ b/src/js/components/MediaDisplay.js
@@ -122,11 +122,23 @@ function bundleMediaEventData(mEvent, imgUrl, videoUrl) {
 }
 
 const OtherChannelLinks = ({ allChannelNames, thisChannel, camera }) => {
-  if (!allChannelNames || allChannelNames.length === 0) {
-    return null
-  }
+  const [channelNames, setChannelNames] = useState(allChannelNames)
+
+  useEffect(() => {
+    function handleChannelNamesChange(event) {
+      const { data: newChannelNames } = event.detail
+      if (newChannelNames) {
+        setChannelNames(newChannelNames)
+      }
+    }
+    window.addEventListener("channel", handleChannelNamesChange)
+    return () => {
+      window.removeEventListener("channel", handleChannelNamesChange)
+    }
+  }, [])
+
   // Filter out the current channel from the list of all channels
-  const filteredChannels = allChannelNames.filter(
+  const filteredChannels = channelNames.filter(
     (channel) => channel !== thisChannel
   )
   const currentUrl = document.location.toString()

--- a/src/js/components/MediaDisplay.js
+++ b/src/js/components/MediaDisplay.js
@@ -142,19 +142,32 @@ const OtherChannelLinks = ({ allChannelNames, thisChannel, camera }) => {
     (channel) => channel !== thisChannel
   )
   const currentUrl = document.location.toString()
+  const buildUrl = (channelName) => {
+    if (currentUrl.endsWith(`${channelName}/current`)) {
+      return currentUrl.replace(thisChannel, channelName)
+    } else {
+      return currentUrl.replace(
+        `channel_name=${thisChannel}`,
+        `channel_name=${channelName}`
+      )
+    }
+  }
   return (
     <div className="other-channels">
-      {filteredChannels.map((channel) => {
-        const channelObj = camera.channels.find((chan) => chan.name === channel)
+      {filteredChannels.map((channelName) => {
+        const channelObj = camera.channels.find(
+          (chan) => chan.name === channelName
+        )
+        console.log("channelObj", channelObj)
         const chanStyle = {
           backgroundColor: channelObj.colour,
           color: channelObj.text_colour,
         }
         // Construct the URL for each channel
-        const channelUrl = currentUrl.replaceAll(thisChannel, channel)
+        const channelUrl = buildUrl(channelName)
         return (
           <a
-            key={channel}
+            key={channelName}
             href={channelUrl}
             style={chanStyle}
             className="button"

--- a/src/js/components/MediaDisplay.js
+++ b/src/js/components/MediaDisplay.js
@@ -47,12 +47,12 @@ export default function MediaDisplay({
           </a>
           <span className="media-seqnum">{mediaEvent.seq_num}</span>
         </h2>
+        <PrevNext initialPrevNext={prevNext} eventUrl={eventUrl} />
         {isCurrent && (
           <TimeSinceLastImageClock metadata={metadata} camera={camera} />
         )}
       </div>
       <div className="event-nav">
-        <PrevNext prevNext={prevNext} eventUrl={eventUrl} />
         <OtherChannelLinks
           allChannelNames={allChannelNames}
           thisChannel={mediaEvent.channel_name}

--- a/src/js/components/MediaDisplay.js
+++ b/src/js/components/MediaDisplay.js
@@ -11,6 +11,7 @@ export default function MediaDisplay({
   imgUrl,
   videoUrl,
   camera,
+  dateUrl,
   metadata,
   eventUrl,
   prevNext,
@@ -19,6 +20,7 @@ export default function MediaDisplay({
   const [mediaEvent, setMediaEvent] = useState(() =>
     unifyMediaEvent(initialEvent, imgUrl, videoUrl)
   )
+
   useEffect(() => {
     const handleChannelEvent = (message) => {
       const { data: event, dataType } = message.detail
@@ -39,7 +41,9 @@ export default function MediaDisplay({
     <>
       <div className="event-info">
         <h2>
-          <span className="media-date">{mediaEvent.day_obs}</span>
+          <a href={dateUrl}>
+            <span className="media-date">{mediaEvent.day_obs}</span>
+          </a>
           <span className="media-seqnum">{mediaEvent.seq_num}</span>
         </h2>
         {isCurrent ? (
@@ -74,6 +78,7 @@ MediaDisplay.propTypes = {
   imgUrl: PropTypes.string.isRequired,
   videoUrl: PropTypes.string.isRequired,
   camera: cameraType,
+  dateUrl: PropTypes.string.isRequired,
   metadata: metadataType,
   eventUrl: PropTypes.string,
   prevNext: PropTypes.shape({

--- a/src/js/components/PrevNext.js
+++ b/src/js/components/PrevNext.js
@@ -3,6 +3,9 @@ import PropTypes from "prop-types"
 import { eventType } from "./componentPropTypes"
 
 export default function PrevNext({ prevNext, eventUrl }) {
+  if (!prevNext) {
+    return null
+  }
   const left = useRef(null)
   const right = useRef(null)
   useEffect(() => {
@@ -21,23 +24,19 @@ export default function PrevNext({ prevNext, eventUrl }) {
   }, [])
   const prev = prevNext.prev
   const next = prevNext.next
+  const makeUrl = (obj) => {
+    const { channel_name, day_obs, seq_num } = obj
+    return `${eventUrl}?channel_name=${channel_name}&date_str=${day_obs}&seq_num=${seq_num}`
+  }
   return (
     <div className="prev-next-buttons">
       {prev && (
-        <a
-          className="prev prev-next button"
-          href={`${eventUrl}?key=${prev.key}`}
-          ref={left}
-        >
+        <a className="prev prev-next button" href={makeUrl(prev)} ref={left}>
           {prev.seq_num}
         </a>
       )}
       {next && (
-        <a
-          className="next prev-next button"
-          href={`${eventUrl}?key=${next.key}`}
-          ref={right}
-        >
+        <a className="next prev-next button" href={makeUrl(next)} ref={right}>
           {next.seq_num}
         </a>
       )}

--- a/src/js/components/PrevNext.js
+++ b/src/js/components/PrevNext.js
@@ -2,7 +2,8 @@ import React, { useEffect, useRef } from "react"
 import PropTypes from "prop-types"
 import { eventType } from "./componentPropTypes"
 
-export default function PrevNext({ prevNext, eventUrl }) {
+export default function PrevNext({ initialPrevNext, eventUrl }) {
+  const [prevNext, setPrevNext] = React.useState(initialPrevNext)
   if (!prevNext) {
     return null
   }
@@ -22,6 +23,22 @@ export default function PrevNext({ prevNext, eventUrl }) {
       document.removeEventListener("keydown", handleKeyDown)
     }
   }, [])
+
+  useEffect(() => {
+    function handleNewPrevNext(e) {
+      const { data, dataType } = e.detail
+      if (dataType == "prevNext") {
+        const { prev, next } = data
+        setPrevNext({ prev, next })
+      }
+    }
+
+    window.addEventListener("channel", handleNewPrevNext)
+    return () => {
+      window.removeEventListener("channel", handleNewPrevNext)
+    }
+  }, [])
+
   const prev = prevNext.prev
   const next = prevNext.next
   const makeUrl = (obj) => {

--- a/src/js/components/TableControls.js
+++ b/src/js/components/TableControls.js
@@ -78,7 +78,7 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
 
   function toggleControls(e) {
     e.stopPropagation()
-    setControlsOpen(!controlsOpen)
+    setControlsOpen((controlsOpen) => !controlsOpen)
   }
 
   const handleCheckboxChange = (name) => {

--- a/src/js/components/TableControls.js
+++ b/src/js/components/TableControls.js
@@ -71,7 +71,6 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
   }
 
   function toggleControls(e) {
-    // Keep open if clicking inside controls
     if (e.target.closest(".table-controls")) {
       return
     }

--- a/src/js/components/TableControls.js
+++ b/src/js/components/TableControls.js
@@ -63,9 +63,8 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
     }
   }, [controlsOpen])
 
-  const handleKeyDown = (event) => {
-    console.log(event.key)
-    if (event.key === "Escape") {
+  const handleKeyDown = (e) => {
+    if (e.key === "Escape") {
       setControlsOpen(false)
     }
   }
@@ -101,7 +100,7 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
       <div className={panelClass}>
         <button
           className="table-control-button"
-          onClick={() => toggleControls}
+          onClick={() => toggleControls(e)}
           onKeyDown={handleKeyDown}
         >
           Add/Remove Columns

--- a/src/js/components/TableControls.js
+++ b/src/js/components/TableControls.js
@@ -56,10 +56,17 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
 
   const locationName = window.APP_DATA.locationName
 
+  // Handle clicks outside to close the panel
   useEffect(() => {
-    window.addEventListener("click", toggleControls)
+    function handleOutsideClick(e) {
+      if (controlsOpen && !e.target.closest(".table-panel")) {
+        setControlsOpen(false)
+      }
+    }
+
+    window.addEventListener("click", handleOutsideClick)
     return () => {
-      window.removeEventListener("click", toggleControls)
+      window.removeEventListener("click", handleOutsideClick)
     }
   }, [controlsOpen])
 
@@ -70,15 +77,8 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
   }
 
   function toggleControls(e) {
-    if (e.target.closest(".table-controls")) {
-      return
-    }
-
-    if (controlsOpen) {
-      setControlsOpen(false)
-    } else if (e.target.classList.contains("table-control-button")) {
-      setControlsOpen(true)
-    }
+    e.stopPropagation()
+    setControlsOpen(!controlsOpen)
   }
 
   const handleCheckboxChange = (name) => {
@@ -100,7 +100,7 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
       <div className={panelClass}>
         <button
           className="table-control-button"
-          onClick={() => toggleControls(e)}
+          onClick={toggleControls}
           onKeyDown={handleKeyDown}
         >
           Add/Remove Columns

--- a/src/js/components/TableControls.js
+++ b/src/js/components/TableControls.js
@@ -1,7 +1,7 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import PropTypes from "prop-types"
 import Clock, { TimeSinceLastImageClock } from "./Clock"
-import { _getById, interleaveSplit } from "../modules/utils"
+import { _getById } from "../modules/utils"
 import { cameraType, metadataType } from "./componentPropTypes"
 
 export default function AboveTableRow({
@@ -16,7 +16,7 @@ export default function AboveTableRow({
   return (
     <div className="row">
       <h3 id="the-date">
-        <span className="date">{date}</span>
+        Data for day: <span className="date">{date}</span>
       </h3>
       <TableControls
         cameraName={camera.name}
@@ -39,8 +39,6 @@ export default function AboveTableRow({
 AboveTableRow.propTypes = {
   /** the names of all metadata columns */
   allColNames: PropTypes.arrayOf(PropTypes.string),
-  /** the current camera */
-  camera: cameraType,
   /** the names of the currently selected columns to display */
   selected: PropTypes.arrayOf(PropTypes.string),
   /** callback function from the parent component TableApp */
@@ -58,20 +56,30 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
 
   const locationName = window.APP_DATA.locationName
 
-  let numControlColumns = 2
-  if (allColNames.length > 45) {
-    numControlColumns = 3
-  }
-  const gridStyle = {
-    gridTemplateColumns: `repeat(${numControlColumns}, 1fr)`,
-  }
+  useEffect(() => {
+    window.addEventListener("click", toggleControls)
+    return () => {
+      window.removeEventListener("click", toggleControls)
+    }
+  }, [controlsOpen])
 
-  const columnsToDisplay = interleaveSplit(allColNames, numControlColumns)
-
-  // allow escape from the table to close the controls
   const handleKeyDown = (event) => {
+    console.log(event.key)
     if (event.key === "Escape") {
       setControlsOpen(false)
+    }
+  }
+
+  function toggleControls(e) {
+    // Keep open if clicking inside controls
+    if (e.target.closest(".table-controls")) {
+      return
+    }
+
+    if (controlsOpen) {
+      setControlsOpen(false)
+    } else if (e.target.classList.contains("table-control-button")) {
+      setControlsOpen(true)
     }
   }
 
@@ -94,20 +102,15 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
       <div className={panelClass}>
         <button
           className="table-control-button"
-          onClick={() => setControlsOpen(!controlsOpen)}
+          onClick={() => toggleControls}
           onKeyDown={handleKeyDown}
-          title="Add/Remove Columns"
-          aria-label="Add/Remove Columns"
-          aria-expanded={controlsOpen}
-          aria-controls="table-controls"
-          aria-haspopup="true"
         >
           Add/Remove Columns
         </button>
 
         {controlsOpen && (
-          <div className="table-controls" style={gridStyle}>
-            {columnsToDisplay.map((title) => (
+          <div className="table-controls">
+            {allColNames.map((title) => (
               <div className="table-control" key={title}>
                 <label htmlFor={title}>
                   <input
@@ -117,6 +120,7 @@ function TableControls({ cameraName, allColNames, selected, setSelected }) {
                     value={1}
                     checked={selected.includes(title)}
                     onChange={() => handleCheckboxChange(title)}
+                    onKeyDown={handleKeyDown}
                   />
                   {title}
                 </label>

--- a/src/js/components/TableView.js
+++ b/src/js/components/TableView.js
@@ -68,7 +68,7 @@ function ChannelCell({ event, chanName, chanColour, noEventReplacement }) {
         <a
           className={`button button-table ${chanName}`}
           style={{ backgroundColor: chanColour }}
-          href={`${eventUrl}?key=${event.key}`}
+          href={`${eventUrl}?channel_name=${chanName}&date_str=${event.day_obs}&seq_num=${event.seq_num}`}
           aria-label={chanName} // Add accessible name
         ></a>
       )}

--- a/src/js/pages/single.js
+++ b/src/js/pages/single.js
@@ -12,6 +12,7 @@ import MediaDisplay from "../components/MediaDisplay"
     locationName,
     camera = {},
     metadata,
+    homeUrl,
     imgUrl,
     videoUrl,
     isCurrent,
@@ -26,6 +27,13 @@ import MediaDisplay from "../components/MediaDisplay"
     ws.subscribe("service", "channel", locationName, camera.name, channel)
   }
 
+  // Set dateUrl to the address of the day's page
+  const suffix = isCurrent ? "" : `date/${initEvent.day_obs}`
+  const dateUrl = new URL(
+    `${locationName}/${camera.name}/${suffix}`,
+    homeUrl
+  ).toString()
+
   // Render the MediaDisplay component instead of manually handling DOM updates
   const mediaDisplayRoot = createRoot(_getById("event-display"))
   mediaDisplayRoot.render(
@@ -33,6 +41,7 @@ import MediaDisplay from "../components/MediaDisplay"
       initialEvent={initEvent}
       imgUrl={imgUrl}
       videoUrl={videoUrl}
+      dateUrl={dateUrl}
       camera={camera}
       metadata={metadata}
       eventUrl={eventUrl}

--- a/src/js/pages/single.js
+++ b/src/js/pages/single.js
@@ -18,6 +18,7 @@ import MediaDisplay from "../components/MediaDisplay"
     isCurrent,
     eventUrl,
     prevNext,
+    allChannelNames,
   } = window.APP_DATA
   const channel = initEvent.channel_name
 
@@ -46,6 +47,7 @@ import MediaDisplay from "../components/MediaDisplay"
       metadata={metadata}
       eventUrl={eventUrl}
       prevNext={prevNext}
+      allChannelNames={allChannelNames}
       isCurrent={isCurrent}
     />
   )

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -217,7 +217,6 @@ section
 		color: #fff
 		text-decoration: underline
 	.media-seqnum
-		margin-right: 0.5em
 		&::before
 			content: "Sequence "
 
@@ -248,6 +247,7 @@ section
 	display: flex
 	flex-direction: row
 	gap: 1em
+	margin-bottom: 1em
 
 .metadata-status
 	display: flex

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -244,6 +244,12 @@ section
 	.next:after
 		content: "→"
 
+.other-channels
+	display: flex
+	flex-direction: row
+	gap: 1em
+	margin-left: 1em
+
 .metadata-status
 	display: flex
 	align-items: center

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -203,6 +203,13 @@ section
 	> *
 		margin-right: 1em
 
+.event-nav
+	display: flex
+	flex-direction: row
+	justify-content: flex-start
+	align-items: center
+	gap: 1em
+	margin-bottom: 1em
 .event-info
 	display: flex
 	flex-direction: row
@@ -213,13 +220,12 @@ section
 		margin-bottom: 0
 	.media-date
 		margin-right: 0.5em
+		color: #fff
+		text-decoration: underline
 	.media-seqnum
 		margin-right: 0.5em
 		&::before
 			content: "Sequence "
-	a
-		color: #fff
-		text-decoration: underline
 
 .event-link
 	color: #fff

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -217,6 +217,9 @@ section
 		margin-right: 0.5em
 		&::before
 			content: "Sequence "
+	a
+		color: #fff
+		text-decoration: underline
 
 .event-link
 	color: #fff
@@ -234,6 +237,8 @@ section
 	.button
 		flex-direction: row
 		gap: 0.25em
+		color: #000
+		text-decoration: none
 	.prev:before
 		content: "←"
 	.next:after

--- a/src/sass/style.sass
+++ b/src/sass/style.sass
@@ -203,19 +203,13 @@ section
 	> *
 		margin-right: 1em
 
-.event-nav
-	display: flex
-	flex-direction: row
-	justify-content: flex-start
-	align-items: center
-	gap: 1em
-	margin-bottom: 1em
 .event-info
 	display: flex
 	flex-direction: row
 	justify-content: flex-start
 	align-items: center
 	margin-bottom: 0.5em
+	gap: 1em
 	h2
 		margin-bottom: 0
 	.media-date
@@ -254,7 +248,6 @@ section
 	display: flex
 	flex-direction: row
 	gap: 1em
-	margin-left: 1em
 
 .metadata-status
 	display: flex

--- a/tests/background/currentpoller_test.py
+++ b/tests/background/currentpoller_test.py
@@ -138,14 +138,14 @@ async def test_process_channel_objects(
     objects = rubin_data_mocker.seq_objs[loc_cam]
 
     # Call the method under test
-    await current_poller.process_channel_objects(objects, loc_cam, camera)
+    await current_poller.process_channel_objects(objects, location, camera)
 
     # Expected events
     expected_events = rubin_data_mocker.events[loc_cam]
 
     # Assertions
     mock_update_channel_events.assert_called_once_with(
-        expected_events, "summit-usdf/auxtel", camera
+        expected_events, location, camera
     )
     mock_make_per_day_data.assert_called()
     mock_notify_ws_clients.assert_called()
@@ -164,8 +164,7 @@ async def test_update_channel_events(
 
     await current_poller.clear_todays_data()
     assert current_poller._most_recent_events == {}
-    loc_cam = f"{location.name}/{camera.name}"
-    await current_poller.update_channel_events(events, loc_cam, camera)
+    await current_poller.update_channel_events(events, location, camera)
     assert current_poller._most_recent_events != {}
     mock_notify_ws_clients.assert_called()
 


### PR DESCRIPTION
By request, this PR seeks to add:

- A link to take the user from any event page (single image) to the table for that camera and day.
- A means to navigate to other channels with events that share the same date and `seq_num`.
- To be able to close the 'add column' controls by clicking away from the box.

It also adds a 'prev' button to current events.