### PR TITLE
DM-54447: Add fixed 'Retrieval fails' column to tables

### DIFF
--- a/python/lsst/ts/rubintv/models/models_data.yaml
+++ b/python/lsst/ts/rubintv/models/models_data.yaml
@@ -668,10 +668,12 @@ metadata_columns:
     Test type: The type of test being run, e.g. superflats
 
   lsstcam:
+    Retrieval fails: Whether retrieval of raw data for this image failed or not
     Exposure time: The image exposure time
     Image type: The image type, e.g. bias, dark, flat etc
 
   lsstcam_aos:
+    Retrieval fails: Whether retrieval of raw data for this image failed or not
     Exposure time: The image exposure time
     Image type: The image type, e.g. bias, dark, flat etc
 

--- a/src/js/components/TableApp.tsx
+++ b/src/js/components/TableApp.tsx
@@ -16,6 +16,11 @@ import {
   SortingOptions,
 } from "./componentTypes"
 import { RubinTVTableContext } from "./contexts/contexts"
+import {
+  getAllColumnNames,
+  redrawHeaderWidths,
+  getDefaultColumns,
+} from "../modules/tableUtils"
 
 type EL = EventListener
 
@@ -44,16 +49,7 @@ export default function TableApp({
 
   const [error, setError] = useState(null)
 
-  // Column configuration derived from camera metadata
-  const defaultColumns = camera.metadata_columns
-    ? Object.entries(camera.metadata_columns).map(
-        ([name, desc]) =>
-          ({
-            name,
-            desc,
-          }) as MetadataColumn
-      )
-    : []
+  const defaultColumns = getDefaultColumns(camera)
   const defaultColNames = defaultColumns.map((col) => col.name)
   const availableColumns = getAllColumnNames(metadata, defaultColNames)
 
@@ -284,68 +280,4 @@ function LoadingBar({
       ></div>
     </div>
   )
-}
-
-function getAllColumnNames(metadata: Metadata, defaultColNames: string[]) {
-  // get the set of all data for list of all available attrs
-  const availableColumns = Object.values(metadata)
-    .map((obj) => Object.keys(obj))
-    .flat()
-    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
-  // get the set of all data for list of all available attrs
-  const uniqueColNames = Array.from(
-    new Set(defaultColNames.concat(availableColumns))
-  )
-  // filter out the indicators (first char is '_')
-  // and the replacement strings for empty channels
-  // (first char is '@')
-  const filtered = uniqueColNames.filter(
-    (el) => !(el[0] === "_" || el[0] === "@")
-  )
-  return filtered
-}
-
-function getTableColumnWidths() {
-  const tRow = document.querySelector("tr")
-  if (!tRow) {
-    return []
-  }
-  const cellsArr = Array.from(tRow.querySelectorAll("td"))
-  const cellWidths = cellsArr.map((cell) => {
-    return cell.offsetWidth
-  })
-  return cellWidths
-}
-
-/**
- * Redraws the header widths based on the current table column widths.
- */
-function redrawHeaderWidths() {
-  const columns = getTableColumnWidths()
-  const headers = Array.from(document.querySelectorAll(".grid-title"))
-  if (columns.length !== headers.length) {
-    return false
-  }
-  let sum = 0
-  for (let ix = 0; ix < headers.length; ix++) {
-    const title = headers[ix] as HTMLElement
-    const width = columns[ix] + 2
-    title.style.left = `${sum}px`
-    sum += width
-  }
-  if (sum > 0) {
-    const sumWidth = `${Math.ceil(sum) + 2}px`
-    const aboveTable = document.querySelector(
-      ".above-table-sticky"
-    ) as HTMLElement
-    const tableHeader = document.querySelector(".table-header") as HTMLElement
-    if (aboveTable) {
-      aboveTable.style.width = sumWidth
-    }
-    if (tableHeader) {
-      tableHeader.style.width = sumWidth
-    }
-    return true
-  }
-  return false
 }

--- a/src/js/components/TableControls.tsx
+++ b/src/js/components/TableControls.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useContext, KeyboardEvent } from "react"
 import Clock, { TimeSinceLastImageClock } from "./Clock"
 import { _getById, getImageAssetUrl } from "../modules/utils"
+import { alwaysSelectedColumns } from "../config"
 import { saveColumnSelection } from "../modules/columnStorage"
 import {
   Metadata,
@@ -125,6 +126,7 @@ function TableControls({
   const renderCheckbox = (title: string) => {
     const isAvailable = availableColumns.includes(title)
     const isSelected = selected.includes(title)
+    const isAlwaysSelected = alwaysSelectedColumns.includes(title)
 
     return (
       <div
@@ -132,16 +134,28 @@ function TableControls({
         key={title}
       >
         <label htmlFor={title}>
-          <input
-            type="checkbox"
-            id={title}
-            name={title}
-            value={1}
-            checked={isSelected}
-            onChange={() => handleCheckboxChange(title)}
-            onKeyDown={handleKeyDown}
-            disabled={!isAvailable}
-          />
+          {isAlwaysSelected ? (
+            <input
+              type="checkbox"
+              id={title}
+              name={title}
+              value={1}
+              checked={true}
+              disabled={true}
+              readOnly={true}
+            />
+          ) : (
+            <input
+              type="checkbox"
+              id={title}
+              name={title}
+              value={1}
+              checked={isSelected}
+              onChange={() => handleCheckboxChange(title)}
+              onKeyDown={handleKeyDown}
+              disabled={!isAvailable}
+            />
+          )}
           {title}
         </label>
       </div>

--- a/src/js/components/tests/TableControls.test.js
+++ b/src/js/components/tests/TableControls.test.js
@@ -6,6 +6,7 @@ import AboveTableRow, { JumpButtons } from "../TableControls"
 import { RubinTVTableContext } from "../contexts/contexts"
 import { saveColumnSelection } from "../../modules/columnStorage"
 import { _getById } from "../../modules/utils"
+import * as config from "../../config"
 
 /* global jest, describe, it, expect, beforeEach, beforeAll, afterAll */
 
@@ -466,6 +467,48 @@ describe("TableControls Component", () => {
     const labels = checkboxes.map((checkbox) => checkbox.getAttribute("name"))
 
     expect(labels).toEqual(["alpha", "Beta", "zebra"])
+  })
+
+  it("should always set always selected columns as checked and read-only", () => {
+    const originalValue = config.alwaysSelectedColumns
+    // eslint-disable-next-line no-import-assign
+    Object.defineProperty(config, "alwaysSelectedColumns", {
+      value: ["colA"],
+      configurable: true,
+    })
+
+    const alwaysSelectedProps = {
+      ...defaultProps,
+      availableColumns: ["colA", "colB"],
+      selected: ["colA", "colB"],
+    }
+
+    render(
+      <RubinTVTableContext.Provider value={mockContextValue}>
+        <AboveTableRow
+          {...alwaysSelectedProps}
+          camera={{ name: "testcam", channels: [] }}
+          date="2024-01-01"
+          metadata={{}}
+          isHistorical={false}
+        />
+      </RubinTVTableContext.Provider>
+    )
+
+    const button = screen.getByRole("button", { name: /add\/remove columns/i })
+    fireEvent.click(button)
+
+    const alwaysSelectedCheckbox = screen.getByRole("checkbox", {
+      name: "colA",
+    })
+    expect(alwaysSelectedCheckbox).toBeChecked()
+    expect(alwaysSelectedCheckbox).toBeDisabled()
+    expect(alwaysSelectedCheckbox).toHaveAttribute("readOnly")
+    // eslint-disable-next-line no-import-assign
+    Object.defineProperty(config, "alwaysSelectedColumns", {
+      value: originalValue,
+      configurable: true,
+    })
   })
 })
 

--- a/src/js/components/tests/TableView.test.js
+++ b/src/js/components/tests/TableView.test.js
@@ -411,6 +411,47 @@ describe("TableView Components", () => {
         screen.queryByRole("link", { name: /open image viewer/i })
       ).not.toBeInTheDocument()
     })
+
+    it("displays always-selected columns first in metadata section", () => {
+      const metadataWithAlwaysSelected = {
+        100: {
+          "Retrieval fails": "No",
+          exposure_time: 30.5,
+          filter: "r",
+        },
+      }
+
+      const metadataColumnsWithAlwaysSelected = [
+        { name: "Retrieval fails", desc: "Whether retrieval failed" },
+        { name: "exposure_time", desc: "Exposure time in seconds" },
+        { name: "filter", desc: "Filter used" },
+      ]
+
+      const { container } = render(
+        <TestWrapper>
+          <table>
+            <tbody>
+              <TableRow
+                seqNum="100"
+                camera={mockCamera}
+                channels={mockCamera.channels.filter((c) => !c.per_day)}
+                channelRow={mockChannelData["100"]}
+                metadataColumns={metadataColumnsWithAlwaysSelected}
+                metadataRow={metadataWithAlwaysSelected[100]}
+              />
+            </tbody>
+          </table>
+        </TestWrapper>
+      )
+
+      const metadataCells = container.querySelectorAll(".grid-cell.meta")
+      // First metadata cell should be "Retrieval fails"
+      expect(metadataCells[0]).toHaveTextContent("No")
+      // Second should be exposure_time
+      expect(metadataCells[1]).toHaveTextContent("30.5")
+      // Third should be filter
+      expect(metadataCells[2]).toHaveTextContent("r")
+    })
   })
 
   describe("FoldoutCell", () => {

--- a/src/js/config.ts
+++ b/src/js/config.ts
@@ -24,3 +24,5 @@ export const hasCCS = (siteLoc: string) => {
 export const hasFOV = (siteLoc: string) => {
   return ["summit", "usdf-k8s", "local"].includes(siteLoc)
 }
+
+export const alwaysSelectedColumns = ["Retrieval fails"]

--- a/src/js/modules/tableUtils.ts
+++ b/src/js/modules/tableUtils.ts
@@ -1,0 +1,81 @@
+import { Camera, Metadata, MetadataColumn } from "../components/componentTypes"
+
+export function getAllColumnNames(
+  metadata: Metadata,
+  defaultColNames: string[]
+) {
+  // get the set of all data for list of all available attrs
+  const availableColumns = Object.values(metadata)
+    .map((obj) => Object.keys(obj))
+    .flat()
+    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+  // get the set of all data for list of all available attrs
+  const uniqueColNames = Array.from(
+    new Set(defaultColNames.concat(availableColumns))
+  )
+  // filter out the indicators (first char is '_')
+  // and the replacement strings for empty channels
+  // (first char is '@')
+  const filtered = uniqueColNames.filter(
+    (el) => !(el[0] === "_" || el[0] === "@")
+  )
+  return filtered
+}
+
+export function getTableColumnWidths() {
+  const tRow = document.querySelector("tr")
+  if (!tRow) {
+    return []
+  }
+  const cellsArr = Array.from(tRow.querySelectorAll("td"))
+  const cellWidths = cellsArr.map((cell) => {
+    return cell.offsetWidth
+  })
+  return cellWidths
+}
+
+/**
+ * Redraws the header widths based on the current table column widths.
+ */
+export function redrawHeaderWidths() {
+  const columns = getTableColumnWidths()
+  const headers = Array.from(document.querySelectorAll(".grid-title"))
+  if (columns.length !== headers.length) {
+    return false
+  }
+  let sum = 0
+  for (let ix = 0; ix < headers.length; ix++) {
+    const title = headers[ix] as HTMLElement
+    const width = columns[ix] + 2
+    title.style.left = `${sum}px`
+    sum += width
+  }
+  if (sum > 0) {
+    const sumWidth = `${Math.ceil(sum) + 2}px`
+    const aboveTable = document.querySelector(
+      ".above-table-sticky"
+    ) as HTMLElement
+    const tableHeader = document.querySelector(".table-header") as HTMLElement
+    if (aboveTable) {
+      aboveTable.style.width = sumWidth
+    }
+    if (tableHeader) {
+      tableHeader.style.width = sumWidth
+    }
+    return true
+  }
+  return false
+}
+
+// Column configuration derived from camera metadata
+export function getDefaultColumns(camera: Camera) {
+  return camera.metadata_columns
+    ? Object.entries(camera.metadata_columns).map(
+        ([name, desc]) =>
+          ({
+            name,
+            desc,
+          }) as MetadataColumn
+      )
+    : []
+}

--- a/src/js/modules/tests/tableUtils.test.js
+++ b/src/js/modules/tests/tableUtils.test.js
@@ -1,0 +1,72 @@
+import "@testing-library/jest-dom"
+import { getAllColumnNames, getDefaultColumns } from "../tableUtils"
+
+/* global describe, it, expect */
+
+describe("getAllColumnNames", () => {
+  it("should return all column names including default and available columns", () => {
+    const metadata = {
+      1: { "Column 1": "data" },
+      2: { "Column 2": "data" },
+    }
+    const defaultColNames = ["Column 1"]
+
+    const result = getAllColumnNames(metadata, defaultColNames)
+    expect(result).toEqual(["Column 1", "Column 2"])
+  })
+
+  it("should return all column names when there are no non-selectable columns", () => {
+    const metadata = {
+      1: { "Column 1": "data" },
+      2: { "Column 2": "data" },
+    }
+    const defaultColNames = ["Column 1", "Column 2"]
+    const nonSelectableCols = []
+
+    const result = getAllColumnNames(
+      metadata,
+      defaultColNames,
+      nonSelectableCols
+    )
+    expect(result).toEqual(["Column 1", "Column 2"])
+  })
+
+  it("should return empty array when there are no columns in metadata", () => {
+    const metadata = {}
+    const defaultColNames = []
+    const nonSelectableCols = []
+
+    const result = getAllColumnNames(
+      metadata,
+      defaultColNames,
+      nonSelectableCols
+    )
+    expect(result).toEqual([])
+  })
+})
+
+describe("getDefaultColumns", () => {
+  it("should return default columns based on camera metadata", () => {
+    const camera = {
+      metadata_columns: {
+        "Column 1": "Description 1",
+        "Column 2": "Description 2",
+      },
+    }
+
+    const result = getDefaultColumns(camera)
+    expect(result).toEqual([
+      { name: "Column 1", desc: "Description 1" },
+      { name: "Column 2", desc: "Description 2" },
+    ])
+  })
+
+  it("should return empty array when camera has no metadata columns", () => {
+    const camera = {
+      metadata_columns: null,
+    }
+
+    const result = getDefaultColumns(camera)
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
If 'Retrieval fails' exists in the metadata, it should be always be shown as the first column of metadata.
To acheive that, the column has been added as a default to LSSTCam and AOS and the option to uncheck its selection removed.